### PR TITLE
feat: PostgreSQL schema + migrations (#13)

### DIFF
--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -1,0 +1,49 @@
+-- Trust evaluation results (Pass2 output) — scalar facts only
+CREATE TABLE trust_results (
+  did             TEXT PRIMARY KEY,
+  trust_status    TEXT NOT NULL,       -- TRUSTED / PARTIAL / UNTRUSTED
+  production      BOOLEAN NOT NULL,
+  evaluated_at    TIMESTAMPTZ NOT NULL,
+  evaluated_block BIGINT NOT NULL,
+  expires_at      TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_trust_expires ON trust_results(expires_at)
+  WHERE expires_at <= NOW();
+
+-- Per-credential evaluation results, linked to the DID
+CREATE TABLE credential_results (
+  id              BIGSERIAL PRIMARY KEY,
+  did             TEXT NOT NULL REFERENCES trust_results(did) ON DELETE CASCADE,
+  credential_id   TEXT NOT NULL,       -- VC id or hash
+  result_status   TEXT NOT NULL,       -- VALID / IGNORED / FAILED
+  ecs_type        TEXT,                -- ECS-SERVICE, ECS-ORG, ECS-PERSONA, ECS-UA, or NULL
+  schema_id       BIGINT,
+  issuer_did      TEXT,
+  presented_by    TEXT,
+  issued_by       TEXT,
+  perm_id         BIGINT,
+  error_reason    TEXT,                -- populated when result_status = FAILED
+  UNIQUE (did, credential_id)
+);
+
+CREATE INDEX idx_cred_did ON credential_results(did);
+
+-- Retry tracking for failed dereferencing / evaluation
+CREATE TABLE reattemptable (
+  resource_id     TEXT PRIMARY KEY,
+  resource_type   TEXT NOT NULL,       -- DID_DOC / VP / VC / TRUST_EVAL
+  first_failure   TIMESTAMPTZ NOT NULL,
+  last_retry      TIMESTAMPTZ NOT NULL,
+  error_type      TEXT,                -- TRANSIENT / PERMANENT
+  retry_count     INTEGER NOT NULL DEFAULT 0
+);
+
+-- Resolver state (singleton key-value rows)
+CREATE TABLE resolver_state (
+  key             TEXT PRIMARY KEY,
+  value           TEXT NOT NULL
+);
+
+-- Seed initial state
+INSERT INTO resolver_state (key, value) VALUES ('lastProcessedBlock', '0');

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,0 +1,33 @@
+import pg from 'pg';
+import { getConfig } from '../config/index.js';
+
+const { Pool } = pg;
+
+let _pool: pg.Pool | null = null;
+
+export function getPool(): pg.Pool {
+  if (_pool === null) {
+    const config = getConfig();
+    _pool = new Pool({
+      connectionString: config.DATABASE_URL,
+      max: 20,
+      idleTimeoutMillis: 30000,
+      connectionTimeoutMillis: 5000,
+    });
+  }
+  return _pool;
+}
+
+export async function query<T extends pg.QueryResultRow>(
+  text: string,
+  params?: unknown[],
+): Promise<pg.QueryResult<T>> {
+  return getPool().query<T>(text, params);
+}
+
+export async function closePool(): Promise<void> {
+  if (_pool !== null) {
+    await _pool.end();
+    _pool = null;
+  }
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,2 @@
+export { getPool, query, closePool } from './client.js';
+export { runMigrations, getPendingMigrations } from './migrate.js';

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,0 +1,60 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import pg from 'pg';
+
+const MIGRATIONS_DIR = new URL('../../migrations', import.meta.url).pathname;
+
+interface MigrationRecord {
+  id: number;
+  name: string;
+  applied_at: Date;
+}
+
+export async function ensureMigrationsTable(pool: pg.Pool): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      id SERIAL PRIMARY KEY,
+      name TEXT NOT NULL UNIQUE,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+  `);
+}
+
+export async function getAppliedMigrations(pool: pg.Pool): Promise<string[]> {
+  const result = await pool.query<MigrationRecord>(
+    'SELECT name FROM schema_migrations ORDER BY id ASC',
+  );
+  return result.rows.map((row) => row.name);
+}
+
+export async function getPendingMigrations(pool: pg.Pool): Promise<string[]> {
+  const applied = await getAppliedMigrations(pool);
+  const files = await readdir(MIGRATIONS_DIR);
+  const sqlFiles = files.filter((f) => f.endsWith('.sql')).sort();
+  return sqlFiles.filter((f) => !applied.includes(f));
+}
+
+export async function runMigrations(pool: pg.Pool): Promise<string[]> {
+  await ensureMigrationsTable(pool);
+  const pending = await getPendingMigrations(pool);
+
+  const applied: string[] = [];
+  for (const migration of pending) {
+    const sql = await readFile(join(MIGRATIONS_DIR, migration), 'utf-8');
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(sql);
+      await client.query('INSERT INTO schema_migrations (name) VALUES ($1)', [migration]);
+      await client.query('COMMIT');
+      applied.push(migration);
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw new Error(`Migration ${migration} failed: ${String(err)}`);
+    } finally {
+      client.release();
+    }
+  }
+
+  return applied;
+}

--- a/test/db-client.test.ts
+++ b/test/db-client.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadConfig } from '../src/config/index.js';
+
+describe('db client configuration', () => {
+  beforeEach(() => {
+    loadConfig({
+      DATABASE_URL: 'postgresql://localhost:5432/verana_resolver_test',
+      REDIS_URL: 'redis://localhost:6379',
+    });
+  });
+
+  it('config includes DATABASE_URL', () => {
+    const config = loadConfig({
+      DATABASE_URL: 'postgresql://localhost:5432/verana_resolver_test',
+      REDIS_URL: 'redis://localhost:6379',
+    });
+    expect(config.DATABASE_URL).toBe('postgresql://localhost:5432/verana_resolver_test');
+  });
+
+  it('rejects invalid DATABASE_URL', () => {
+    expect(() =>
+      loadConfig({
+        DATABASE_URL: 'not-a-url',
+        REDIS_URL: 'redis://localhost:6379',
+      }),
+    ).toThrow('Invalid configuration');
+  });
+});
+
+describe('migration SQL', () => {
+  it('001_initial_schema.sql exists and contains expected tables', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+    const migrationsDir = join(import.meta.dirname, '..', 'migrations');
+    const sql = await readFile(join(migrationsDir, '001_initial_schema.sql'), 'utf-8');
+
+    expect(sql).toContain('CREATE TABLE trust_results');
+    expect(sql).toContain('CREATE TABLE credential_results');
+    expect(sql).toContain('CREATE TABLE reattemptable');
+    expect(sql).toContain('CREATE TABLE resolver_state');
+    expect(sql).toContain("INSERT INTO resolver_state (key, value) VALUES ('lastProcessedBlock', '0')");
+    expect(sql).toContain('idx_trust_expires');
+    expect(sql).toContain('idx_cred_did');
+  });
+});


### PR DESCRIPTION
## Summary

PostgreSQL schema, migration system, and database client for the Verana Trust Resolver.

Closes #13

## What's included

### Migration system (`src/db/migrate.ts`)
- Simple SQL-file-based migration runner (no external CLI dependency)
- Tracks applied migrations in `schema_migrations` table
- Transactional per migration — rollback on failure
- `runMigrations(pool)` applies all pending migrations in order

### Initial migration (`migrations/001_initial_schema.sql`)

| Table | Purpose |
|-------|---------|
| `trust_results` | Pre-computed Q1 trust evaluations (scalar facts only) |
| `credential_results` | Per-credential evaluation results linked to DID |
| `reattemptable` | Retry tracking for failed dereferencing / evaluation |
| `resolver_state` | Singleton key-value store (lastProcessedBlock, leader lock) |

Indexes:
- `idx_trust_expires` — partial index on `trust_results(expires_at)` for TTL-driven refresh queries
- `idx_cred_did` — index on `credential_results(did)` for credential lookups by DID

Seeds `resolver_state` with `lastProcessedBlock = 0`.

### Database client (`src/db/client.ts`)
- Connection pool via `pg.Pool` using `DATABASE_URL` from config
- Pool size: 20 connections, 5s connect timeout, 30s idle timeout
- `query()` helper for typed queries
- `closePool()` for graceful shutdown

### Tests
- Config validation for `DATABASE_URL`
- Migration SQL file validation (all tables, indexes, seed data present)

## Dependencies
- Depends on #12 (Project bootstrap + configuration) ✅ merged