### PR TITLE
feat: Redis client + downloaded file cache (#14)

### DIFF
--- a/src/cache/file-cache.ts
+++ b/src/cache/file-cache.ts
@@ -1,0 +1,91 @@
+import { getRedis, isRedisReady } from './redis-client.js';
+import { getConfig } from '../config/index.js';
+
+const KEY_PREFIX = 'resolver:obj:';
+const STATE_PREFIX = 'resolver:state:';
+
+export function objectKey(urlOrDid: string): string {
+  return `${KEY_PREFIX}${urlOrDid}`;
+}
+
+export function stateKey(name: string): string {
+  return `${STATE_PREFIX}${name}`;
+}
+
+export async function getCachedFile(urlOrDid: string): Promise<string | null> {
+  if (!isRedisReady()) return null;
+  try {
+    return await getRedis().get(objectKey(urlOrDid));
+  } catch {
+    return null;
+  }
+}
+
+export async function setCachedFile(urlOrDid: string, content: string): Promise<void> {
+  if (!isRedisReady()) return;
+  const config = getConfig();
+  try {
+    await getRedis().set(objectKey(urlOrDid), content, 'EX', config.CACHE_TTL);
+  } catch {
+    // Redis is a performance optimization, not a correctness requirement
+  }
+}
+
+export async function deleteCachedFile(urlOrDid: string): Promise<void> {
+  if (!isRedisReady()) return;
+  try {
+    await getRedis().del(objectKey(urlOrDid));
+  } catch {
+    // Best effort
+  }
+}
+
+export async function deleteCachedFiles(urlsOrDids: string[]): Promise<void> {
+  if (!isRedisReady() || urlsOrDids.length === 0) return;
+  try {
+    const keys = urlsOrDids.map(objectKey);
+    await getRedis().del(...keys);
+  } catch {
+    // Best effort
+  }
+}
+
+export async function setCachedFilesBatch(
+  entries: Array<{ urlOrDid: string; content: string }>,
+  batchSize = 100,
+): Promise<void> {
+  if (!isRedisReady() || entries.length === 0) return;
+  const config = getConfig();
+  const redis = getRedis();
+
+  try {
+    for (let i = 0; i < entries.length; i += batchSize) {
+      const batch = entries.slice(i, i + batchSize);
+      const pipeline = redis.pipeline();
+      for (const entry of batch) {
+        pipeline.set(objectKey(entry.urlOrDid), entry.content, 'EX', config.CACHE_TTL);
+      }
+      await pipeline.exec();
+    }
+  } catch {
+    // Best effort
+  }
+}
+
+export async function getState(name: string): Promise<string | null> {
+  if (!isRedisReady()) return null;
+  try {
+    return await getRedis().get(stateKey(name));
+  } catch {
+    return null;
+  }
+}
+
+export async function setState(name: string, value: string): Promise<void> {
+  if (!isRedisReady()) return;
+  try {
+    await getRedis().set(stateKey(name), value);
+  } catch {
+    // Best effort
+  }
+}

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,0 +1,12 @@
+export { getRedis, connectRedis, disconnectRedis, isRedisReady } from './redis-client.js';
+export {
+  getCachedFile,
+  setCachedFile,
+  deleteCachedFile,
+  deleteCachedFiles,
+  setCachedFilesBatch,
+  getState,
+  setState,
+  objectKey,
+  stateKey,
+} from './file-cache.js';

--- a/src/cache/redis-client.ts
+++ b/src/cache/redis-client.ts
@@ -1,0 +1,37 @@
+import Redis from 'ioredis';
+import { getConfig } from '../config/index.js';
+
+let _redis: Redis | null = null;
+
+export function getRedis(): Redis {
+  if (_redis === null) {
+    const config = getConfig();
+    _redis = new Redis(config.REDIS_URL, {
+      maxRetriesPerRequest: 3,
+      retryStrategy(times: number): number | null {
+        if (times > 5) return null;
+        return Math.min(times * 200, 2000);
+      },
+      lazyConnect: true,
+    });
+  }
+  return _redis;
+}
+
+export async function connectRedis(): Promise<void> {
+  const redis = getRedis();
+  if (redis.status === 'wait') {
+    await redis.connect();
+  }
+}
+
+export async function disconnectRedis(): Promise<void> {
+  if (_redis !== null) {
+    await _redis.quit();
+    _redis = null;
+  }
+}
+
+export function isRedisReady(): boolean {
+  return _redis !== null && _redis.status === 'ready';
+}

--- a/test/file-cache.test.ts
+++ b/test/file-cache.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { objectKey, stateKey } from '../src/cache/file-cache.js';
+
+describe('cache key formatting', () => {
+  it('formats object keys with prefix', () => {
+    expect(objectKey('did:web:example.com')).toBe('resolver:obj:did:web:example.com');
+    expect(objectKey('https://example.com/vp/1')).toBe(
+      'resolver:obj:https://example.com/vp/1',
+    );
+  });
+
+  it('formats state keys with prefix', () => {
+    expect(stateKey('lastBlock')).toBe('resolver:state:lastBlock');
+  });
+});
+
+describe('file cache operations (no Redis)', () => {
+  it('getCachedFile returns null when Redis is not connected', async () => {
+    const { getCachedFile } = await import('../src/cache/file-cache.js');
+    const result = await getCachedFile('did:web:example.com');
+    expect(result).toBeNull();
+  });
+
+  it('setCachedFile does not throw when Redis is not connected', async () => {
+    const { setCachedFile } = await import('../src/cache/file-cache.js');
+    await expect(setCachedFile('did:web:example.com', '{}')).resolves.toBeUndefined();
+  });
+
+  it('deleteCachedFile does not throw when Redis is not connected', async () => {
+    const { deleteCachedFile } = await import('../src/cache/file-cache.js');
+    await expect(deleteCachedFile('did:web:example.com')).resolves.toBeUndefined();
+  });
+
+  it('setCachedFilesBatch does not throw when Redis is not connected', async () => {
+    const { setCachedFilesBatch } = await import('../src/cache/file-cache.js');
+    await expect(
+      setCachedFilesBatch([
+        { urlOrDid: 'did:web:a.com', content: '{}' },
+        { urlOrDid: 'did:web:b.com', content: '{}' },
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  it('getState returns null when Redis is not connected', async () => {
+    const { getState } = await import('../src/cache/file-cache.js');
+    const result = await getState('lastBlock');
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Redis client and downloaded file cache layer for the Verana Trust Resolver.

Closes #14

## What's included

### Redis client (`src/cache/redis-client.ts`)
- ioredis client connecting via `REDIS_URL`
- Retry strategy with exponential backoff (max 5 retries)
- Lazy connect — doesn't block startup if Redis is unavailable
- `connectRedis()` / `disconnectRedis()` for lifecycle management
- `isRedisReady()` guard used by all cache operations

### File cache (`src/cache/file-cache.ts`)

| Operation | Function | Description |
|-----------|----------|-------------|
| GET | `getCachedFile(urlOrDid)` | Returns cached file or `null` on miss/error |
| SET | `setCachedFile(urlOrDid, content)` | Stores file with `CACHE_TTL` expiry |
| DEL | `deleteCachedFile(urlOrDid)` | Invalidates a single cached file |
| DEL batch | `deleteCachedFiles(urlsOrDids[])` | Invalidates multiple keys at once |
| SET batch | `setCachedFilesBatch(entries[], batchSize)` | Pipeline batching (default 100 keys/batch) |
| State GET | `getState(name)` | Read resolver state (e.g., lastBlock) |
| State SET | `setState(name, value)` | Write resolver state (no TTL) |

### Key scheme
```
resolver:obj:{url_or_did}      → downloaded file    TTL = CACHE_TTL
resolver:state:{name}          → state value         no TTL
```

### Fallback behavior
- All operations silently return `null` / no-op when Redis is unreachable
- Redis is a **performance optimization**, not a correctness requirement

### What is NOT cached
- Indexer entities — always queried live
- API responses (Q1–Q4) — computed on demand
- Trust evaluation results — stored in PostgreSQL only

### Tests
- Key formatting (`objectKey`, `stateKey`)
- Graceful degradation: all operations return safely when Redis is not connected

## Dependencies
- Depends on #13 (PostgreSQL schema + migrations) ✅ merged