### PR TITLE
feat: Indexer client — typed HTTP wrapper (#15)

### DIFF
--- a/src/indexer/client.ts
+++ b/src/indexer/client.ts
@@ -1,0 +1,249 @@
+import type {
+  BlockHeightResponse,
+  ChangesResponse,
+  TrustRegistryResponse,
+  CredentialSchemaResponse,
+  CredentialSchemaListResponse,
+  PermissionResponse,
+  PermissionListResponse,
+  PermissionSessionResponse,
+  BeneficiaryResponse,
+  TrustDepositResponse,
+  DigestResponse,
+  ExchangeRateResponse,
+  PriceResponse,
+  ListPermissionsParams,
+  ListCredentialSchemasParams,
+  GetExchangeRateParams,
+  GetPriceParams,
+} from './types.js';
+import { IndexerError } from './errors.js';
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const MAX_RETRIES = 2;
+const RETRY_BASE_MS = 200;
+
+export class IndexerClient {
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+  private readonly memo: Map<string, Promise<unknown>> = new Map();
+
+  constructor(indexerUrl: string, timeoutMs = DEFAULT_TIMEOUT_MS) {
+    this.baseUrl = indexerUrl.replace(/\/$/, '');
+    this.timeoutMs = timeoutMs;
+  }
+
+  clearMemo(): void {
+    this.memo.clear();
+  }
+
+  // --- Indexer ---
+
+  async getBlockHeight(): Promise<BlockHeightResponse> {
+    return this.get<BlockHeightResponse>('/verana/indexer/v1/block-height');
+  }
+
+  async listChanges(blockHeight: number): Promise<ChangesResponse> {
+    return this.get<ChangesResponse>(`/verana/indexer/v1/changes/${blockHeight}`);
+  }
+
+  // --- Trust Registry ---
+
+  async getTrustRegistry(
+    id: string,
+    atBlock?: number,
+  ): Promise<TrustRegistryResponse> {
+    return this.get<TrustRegistryResponse>(`/verana/tr/v1/get/${id}`, {}, atBlock);
+  }
+
+  // --- Credential Schema ---
+
+  async getCredentialSchema(
+    id: string,
+    atBlock?: number,
+  ): Promise<CredentialSchemaResponse> {
+    return this.get<CredentialSchemaResponse>(`/verana/cs/v1/get/${id}`, {}, atBlock);
+  }
+
+  async listCredentialSchemas(
+    params: ListCredentialSchemasParams = {},
+    atBlock?: number,
+  ): Promise<CredentialSchemaListResponse> {
+    return this.get<CredentialSchemaListResponse>('/verana/cs/v1/list', params, atBlock);
+  }
+
+  // --- Permissions ---
+
+  async getPermission(
+    id: string,
+    atBlock?: number,
+  ): Promise<PermissionResponse> {
+    return this.get<PermissionResponse>(`/verana/perm/v1/get/${id}`, {}, atBlock);
+  }
+
+  async listPermissions(
+    params: ListPermissionsParams = {},
+    atBlock?: number,
+  ): Promise<PermissionListResponse> {
+    return this.get<PermissionListResponse>('/verana/perm/v1/list', params, atBlock);
+  }
+
+  async getPermissionSession(
+    id: string,
+    atBlock?: number,
+  ): Promise<PermissionSessionResponse> {
+    return this.get<PermissionSessionResponse>(`/verana/perm/v1/session/get/${id}`, {}, atBlock);
+  }
+
+  async findBeneficiaries(
+    issuerPermId: string,
+    verifierPermId: string,
+    atBlock?: number,
+  ): Promise<BeneficiaryResponse> {
+    return this.get<BeneficiaryResponse>('/verana/perm/v1/beneficiaries', {
+      issuer_perm_id: issuerPermId,
+      verifier_perm_id: verifierPermId,
+    }, atBlock);
+  }
+
+  // --- Trust Deposit ---
+
+  async getTrustDepositByAccount(
+    account: string,
+    atBlock?: number,
+  ): Promise<TrustDepositResponse> {
+    return this.get<TrustDepositResponse>(`/verana/td/v1/get/${account}`, {}, atBlock);
+  }
+
+  // --- Digest ---
+
+  async getDigest(
+    digestSri: string,
+    atBlock?: number,
+  ): Promise<DigestResponse> {
+    return this.get<DigestResponse>(`/verana/di/v1/get/${encodeURIComponent(digestSri)}`, {}, atBlock);
+  }
+
+  // --- Exchange Rate ---
+
+  async getExchangeRate(
+    params: GetExchangeRateParams,
+    atBlock?: number,
+  ): Promise<ExchangeRateResponse> {
+    return this.get<ExchangeRateResponse>('/verana/xr/v1/get', params, atBlock);
+  }
+
+  async getPrice(
+    params: GetPriceParams,
+    atBlock?: number,
+  ): Promise<PriceResponse> {
+    return this.get<PriceResponse>('/verana/xr/v1/price', params, atBlock);
+  }
+
+  // --- Internal ---
+
+  private async get<T>(
+    path: string,
+    params: Record<string, unknown> = {},
+    atBlock?: number,
+  ): Promise<T> {
+    const url = this.buildUrl(path, params);
+    const memoKey = atBlock !== undefined ? `${url}@${atBlock}` : url;
+
+    const existing = this.memo.get(memoKey);
+    if (existing) return existing as Promise<T>;
+
+    const promise = this.fetchWithRetry<T>(url, atBlock);
+    this.memo.set(memoKey, promise);
+    return promise;
+  }
+
+  private async fetchWithRetry<T>(url: string, atBlock?: number, attempt = 0): Promise<T> {
+    const headers: Record<string, string> = {
+      'Accept': 'application/json',
+    };
+    if (atBlock !== undefined) {
+      headers['At-Block-Height'] = String(atBlock);
+    }
+
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+      const response = await fetch(url, {
+        headers,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeout);
+
+      if (response.ok) {
+        return (await response.json()) as T;
+      }
+
+      if (response.status === 404) {
+        throw new IndexerError(
+          `Not found: ${url}`,
+          404,
+          'NOT_FOUND',
+        );
+      }
+
+      if (response.status === 400) {
+        const body = await response.text();
+        throw new IndexerError(
+          `Bad request: ${url} — ${body}`,
+          400,
+          'BAD_REQUEST',
+        );
+      }
+
+      if (response.status >= 500 && attempt < MAX_RETRIES) {
+        await this.backoff(attempt);
+        return this.fetchWithRetry<T>(url, atBlock, attempt + 1);
+      }
+
+      throw new IndexerError(
+        `Server error ${response.status}: ${url}`,
+        response.status,
+        'SERVER',
+      );
+    } catch (err) {
+      if (err instanceof IndexerError) throw err;
+
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        if (attempt < MAX_RETRIES) {
+          await this.backoff(attempt);
+          return this.fetchWithRetry<T>(url, atBlock, attempt + 1);
+        }
+        throw new IndexerError(`Timeout: ${url}`, null, 'TIMEOUT');
+      }
+
+      if (attempt < MAX_RETRIES) {
+        await this.backoff(attempt);
+        return this.fetchWithRetry<T>(url, atBlock, attempt + 1);
+      }
+
+      throw new IndexerError(
+        `Network error: ${url} — ${String(err)}`,
+        null,
+        'NETWORK',
+      );
+    }
+  }
+
+  buildUrl(path: string, params: Record<string, unknown> = {}): string {
+    const url = new URL(path, this.baseUrl);
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+    return url.toString();
+  }
+
+  private async backoff(attempt: number): Promise<void> {
+    const ms = RETRY_BASE_MS * Math.pow(2, attempt);
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/src/indexer/errors.ts
+++ b/src/indexer/errors.ts
@@ -1,0 +1,14 @@
+export class IndexerError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number | null,
+    public readonly errorType: 'NETWORK' | 'NOT_FOUND' | 'SERVER' | 'BAD_REQUEST' | 'TIMEOUT',
+  ) {
+    super(message);
+    this.name = 'IndexerError';
+  }
+}
+
+export function isNotFound(err: unknown): boolean {
+  return err instanceof IndexerError && err.errorType === 'NOT_FOUND';
+}

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1,0 +1,27 @@
+export { IndexerClient } from './client.js';
+export { IndexerError, isNotFound } from './errors.js';
+export type {
+  BlockHeightResponse,
+  ChangesResponse,
+  TrustRegistry,
+  TrustRegistryResponse,
+  CredentialSchema,
+  CredentialSchemaResponse,
+  CredentialSchemaListResponse,
+  Permission,
+  PermissionResponse,
+  PermissionListResponse,
+  PermissionSession,
+  PermissionSessionResponse,
+  BeneficiaryResponse,
+  TrustDeposit,
+  TrustDepositResponse,
+  DigestResponse,
+  ExchangeRate,
+  ExchangeRateResponse,
+  PriceResponse,
+  ListPermissionsParams,
+  ListCredentialSchemasParams,
+  GetExchangeRateParams,
+  GetPriceParams,
+} from './types.js';

--- a/src/indexer/types.ts
+++ b/src/indexer/types.ts
@@ -1,0 +1,255 @@
+export interface BlockHeightResponse {
+  type: string;
+  height: number;
+  timestamp: string;
+}
+
+export interface ActivityItem {
+  timestamp: string;
+  block_height: string;
+  entity_type: string;
+  entity_id: string;
+  account: string;
+  msg: string;
+  changes: Record<string, { old: unknown; new: unknown }>;
+}
+
+export interface ChangesResponse {
+  block_height: number;
+  activity: ActivityItem[];
+}
+
+export interface TrustRegistryDocument {
+  id: string;
+  gfv_id: string;
+  created: string;
+  language: string;
+  url: string;
+  digest_sri: string;
+}
+
+export interface TrustRegistryVersion {
+  id: string;
+  tr_id: string;
+  created: string;
+  version: number;
+  active_since: string;
+  documents: TrustRegistryDocument[];
+}
+
+export interface TrustRegistry {
+  id: string;
+  did: string;
+  controller: string;
+  created: string;
+  modified: string;
+  archived: string | null;
+  deposit: string;
+  aka: string | null;
+  language: string;
+  active_version: number;
+  participants: number;
+  active_schemas: number;
+  archived_schemas: number;
+  weight: string;
+  issued: number;
+  verified: number;
+  ecosystem_slash_events: number;
+  ecosystem_slashed_amount: string;
+  ecosystem_slashed_amount_repaid: string;
+  network_slash_events: number;
+  network_slashed_amount: string;
+  network_slashed_amount_repaid: string;
+  versions: TrustRegistryVersion[];
+}
+
+export interface TrustRegistryResponse {
+  trust_registry: TrustRegistry;
+}
+
+export interface TrustRegistryListResponse {
+  trust_registries: TrustRegistry[];
+}
+
+export interface CredentialSchema {
+  id: string;
+  tr_id: string;
+  title: string;
+  description: string;
+  json_schema: string;
+  created: string;
+  modified: string;
+  archived: string | null;
+  issuer_perm_management_mode: string;
+  verifier_perm_management_mode: string;
+  digest_algorithm: string;
+  participants: number;
+  weight: string;
+  issued: number;
+  verified: number;
+  ecosystem_slash_events: number;
+  ecosystem_slashed_amount: string;
+  network_slash_events: number;
+  network_slashed_amount: string;
+}
+
+export interface CredentialSchemaResponse {
+  credential_schema: CredentialSchema;
+}
+
+export interface CredentialSchemaListResponse {
+  credential_schemas: CredentialSchema[];
+}
+
+export interface Permission {
+  id: string;
+  schema_id: string;
+  type: string;
+  grantee: string;
+  did: string;
+  created: string;
+  modified: string;
+  effective: string;
+  expiration: string | null;
+  revoked: string | null;
+  slashed: string | null;
+  repaid: string | null;
+  deposit: string;
+  country: string;
+  vp_state: string;
+  perm_state: string;
+  validator_perm_id: string | null;
+  issued: number;
+  verified: number;
+  ecosystem_slash_events: number;
+  ecosystem_slashed_amount: string;
+  network_slash_events: number;
+  network_slashed_amount: string;
+}
+
+export interface PermissionResponse {
+  permission: Permission;
+}
+
+export interface PermissionListResponse {
+  permissions: Permission[];
+}
+
+export interface PermissionSessionRecord {
+  issuer_perm_id: string;
+  verifier_perm_id: string;
+  wallet_agent_perm_id: string | null;
+}
+
+export interface PermissionSession {
+  id: string;
+  authority: string;
+  vs_operator: string;
+  agent_perm_id: string;
+  created: string;
+  modified: string;
+  records: PermissionSessionRecord[];
+}
+
+export interface PermissionSessionResponse {
+  permission_session: PermissionSession;
+}
+
+export interface PermissionSessionListResponse {
+  permission_sessions: PermissionSession[];
+}
+
+export interface BeneficiaryResponse {
+  beneficiaries: unknown;
+}
+
+export interface TrustDeposit {
+  account: string;
+  share: string;
+  amount: string;
+  claimable: string;
+  slashed_deposit: string;
+  repaid_deposit: string;
+  last_slashed: string | null;
+  last_repaid: string | null;
+  slash_count: number;
+  last_repaid_by: string;
+}
+
+export interface TrustDepositResponse {
+  trust_deposit: TrustDeposit;
+}
+
+export interface DigestResponse {
+  digest: {
+    digest_sri: string;
+    created: string;
+    creator: string;
+    [key: string]: unknown;
+  };
+}
+
+export interface ExchangeRate {
+  id: string;
+  base_asset_type: string;
+  base_asset: string;
+  quote_asset_type: string;
+  quote_asset: string;
+  rate: string;
+  state: boolean;
+  expire: string | null;
+  created: string;
+  modified: string;
+}
+
+export interface ExchangeRateResponse {
+  exchange_rate: ExchangeRate;
+}
+
+export interface ExchangeRateListResponse {
+  exchange_rates: ExchangeRate[];
+}
+
+export interface PriceResponse {
+  price: string;
+  rate: string;
+  base_amount: string;
+}
+
+export interface ListPermissionsParams {
+  did?: string;
+  grantee?: string;
+  schema_id?: string;
+  type?: 'ISSUER' | 'VERIFIER' | 'ISSUER_GRANTOR' | 'VERIFIER_GRANTOR' | 'ECOSYSTEM' | 'HOLDER';
+  only_valid?: boolean;
+  perm_state?: string;
+  response_max_size?: number;
+  when?: string;
+}
+
+export interface ListCredentialSchemasParams {
+  tr_id?: string;
+  only_active?: boolean;
+  issuer_perm_management_mode?: string;
+  verifier_perm_management_mode?: string;
+  response_max_size?: number;
+  participant?: string;
+}
+
+export interface GetExchangeRateParams {
+  id?: string;
+  base_asset_type?: string;
+  base_asset?: string;
+  quote_asset_type?: string;
+  quote_asset?: string;
+  state?: boolean;
+  expire_ts?: string;
+}
+
+export interface GetPriceParams {
+  base_asset_type: string;
+  base_asset: string;
+  quote_asset_type: string;
+  quote_asset: string;
+  amount: string;
+}

--- a/test/indexer-client.test.ts
+++ b/test/indexer-client.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { IndexerClient } from '../src/indexer/client.js';
+import { IndexerError, isNotFound } from '../src/indexer/errors.js';
+
+describe('IndexerClient', () => {
+  let client: IndexerClient;
+
+  beforeEach(() => {
+    client = new IndexerClient('http://localhost:3001');
+  });
+
+  describe('URL building', () => {
+    it('builds simple path URL', () => {
+      const url = client.buildUrl('/verana/indexer/v1/block-height');
+      expect(url).toBe('http://localhost:3001/verana/indexer/v1/block-height');
+    });
+
+    it('builds URL with path parameter', () => {
+      const url = client.buildUrl('/verana/tr/v1/get/42');
+      expect(url).toBe('http://localhost:3001/verana/tr/v1/get/42');
+    });
+
+    it('builds URL with query parameters', () => {
+      const url = client.buildUrl('/verana/perm/v1/list', {
+        did: 'did:web:example.com',
+        type: 'ISSUER',
+        only_valid: true,
+      });
+      expect(url).toContain('did=did%3Aweb%3Aexample.com');
+      expect(url).toContain('type=ISSUER');
+      expect(url).toContain('only_valid=true');
+    });
+
+    it('skips undefined and null params', () => {
+      const url = client.buildUrl('/verana/perm/v1/list', {
+        did: 'did:web:example.com',
+        type: undefined,
+        schema_id: null,
+      });
+      expect(url).toContain('did=');
+      expect(url).not.toContain('type=');
+      expect(url).not.toContain('schema_id=');
+    });
+
+    it('strips trailing slash from base URL', () => {
+      const c = new IndexerClient('http://localhost:3001/');
+      const url = c.buildUrl('/verana/indexer/v1/block-height');
+      expect(url).toBe('http://localhost:3001/verana/indexer/v1/block-height');
+    });
+  });
+
+  describe('memoization', () => {
+    it('clearMemo resets the cache', () => {
+      client.clearMemo();
+      // No error — just verifies the method exists and runs
+    });
+  });
+
+  describe('IndexerError', () => {
+    it('creates error with all fields', () => {
+      const err = new IndexerError('test', 404, 'NOT_FOUND');
+      expect(err.message).toBe('test');
+      expect(err.statusCode).toBe(404);
+      expect(err.errorType).toBe('NOT_FOUND');
+      expect(err.name).toBe('IndexerError');
+    });
+
+    it('isNotFound returns true for NOT_FOUND errors', () => {
+      expect(isNotFound(new IndexerError('x', 404, 'NOT_FOUND'))).toBe(true);
+    });
+
+    it('isNotFound returns false for other errors', () => {
+      expect(isNotFound(new IndexerError('x', 500, 'SERVER'))).toBe(false);
+      expect(isNotFound(new Error('random'))).toBe(false);
+      expect(isNotFound(null)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Typed HTTP client wrapping the Verana Indexer OpenAPI. All Indexer calls are **hot queries** — the Indexer is co-located and returns in <1ms. No Indexer data is cached in Redis or PostgreSQL.

Closes #15

## What's included

### Types (`src/indexer/types.ts`)
Full TypeScript types for all Indexer API responses, derived from `openapi-indexer.json`:
- `BlockHeightResponse`, `ChangesResponse` — Indexer core
- `TrustRegistry`, `TrustRegistryResponse` — Trust Registry module
- `CredentialSchema`, `CredentialSchemaResponse/ListResponse` — Credential Schema module
- `Permission`, `PermissionResponse/ListResponse` — Permission module
- `PermissionSession`, `PermissionSessionResponse` — Permission Sessions
- `BeneficiaryResponse` — Fee beneficiary lookup
- `TrustDeposit`, `TrustDepositResponse` — Trust Deposit module
- `DigestResponse` — Digest module (effective issuance time)
- `ExchangeRate`, `ExchangeRateResponse`, `PriceResponse` — Exchange Rate module
- Typed parameter interfaces: `ListPermissionsParams`, `ListCredentialSchemasParams`, etc.

### Client (`src/indexer/client.ts`)

| Method | Endpoint | Used by |
|--------|----------|---------|
| `getBlockHeight()` | `/verana/indexer/v1/block-height` | Polling loop |
| `listChanges(blockHeight)` | `/verana/indexer/v1/changes/{h}` | Incremental sync |
| `getTrustRegistry(id)` | `/verana/tr/v1/get/{id}` | Ecosystem metadata |
| `getCredentialSchema(id)` | `/verana/cs/v1/get/{id}` | Q1–Q4 |
| `listCredentialSchemas(params)` | `/verana/cs/v1/list` | Q4 ecosystem lookup |
| `getPermission(id)` | `/verana/perm/v1/get/{id}` | Permission chain |
| `listPermissions(params)` | `/verana/perm/v1/list` | Q1–Q4 |
| `getPermissionSession(id)` | `/verana/perm/v1/session/get/{id}` | Q2/Q3 session check |
| `findBeneficiaries(issuer, verifier)` | `/verana/perm/v1/beneficiaries` | Q2/Q3 fees |
| `getTrustDepositByAccount(account)` | `/verana/td/v1/get/{account}` | Permission chain deposit |
| `getDigest(digestSri)` | `/verana/di/v1/get/{sri}` | Effective issuance time |
| `getExchangeRate(params)` | `/verana/xr/v1/get` | Q2/Q3 fee conversion |
| `getPrice(params)` | `/verana/xr/v1/price` | Q2/Q3 fee conversion |

### Features
- **`At-Block-Height` header** on every call that accepts it
- **Per-request memoization** (`clearMemo()` between requests) to avoid duplicate Indexer calls within a single trust evaluation
- **Timeout + retry** with exponential backoff (max 2 retries, 5s timeout)
- **Structured errors** (`IndexerError`): `NETWORK`, `NOT_FOUND`, `SERVER`, `BAD_REQUEST`, `TIMEOUT`

### Tests
- URL building with path and query params
- Undefined/null param filtering
- Trailing slash normalization
- Memoization reset
- `IndexerError` construction and `isNotFound()` helper

## Dependencies
- Depends on #14 (Redis client + downloaded file cache) ✅ merged