### PR TITLE
feat: implement resolveTrust algorithm (Q1 core)

### DIFF
--- a/src/trust/evaluate-credential.ts
+++ b/src/trust/evaluate-credential.ts
@@ -1,0 +1,275 @@
+import type { IndexerClient } from '../indexer/client.js';
+import type { DereferencedVC } from '../ssi/types.js';
+import type { CredentialSchema, Permission } from '../indexer/types.js';
+import { computeDigestSRI } from '../ssi/digest.js';
+import { verifyW3cCredential, verifyAnonCredsCredential } from '../ssi/vc-verifier.js';
+import { buildPermissionChain } from './permission-chain.js';
+import type {
+  CredentialEvaluation,
+  CredentialSchemaInfo,
+  EcsType,
+  EvaluationContext,
+  FailedCredential,
+} from './types.js';
+
+const ECS_TYPE_PATTERNS: Array<{ pattern: RegExp; ecsType: EcsType }> = [
+  { pattern: /ecs-service/i, ecsType: 'ECS-SERVICE' },
+  { pattern: /ecs-org/i, ecsType: 'ECS-ORG' },
+  { pattern: /ecs-persona/i, ecsType: 'ECS-PERSONA' },
+  { pattern: /ecs-ua/i, ecsType: 'ECS-UA' },
+];
+
+export async function evaluateCredential(
+  vc: DereferencedVC,
+  presentedBy: string,
+  indexer: IndexerClient,
+  ctx: EvaluationContext,
+): Promise<{ credential?: CredentialEvaluation; failed?: FailedCredential }> {
+  try {
+    // 1. Verify signature
+    const verifyResult = vc.format === 'anoncreds'
+      ? await verifyAnonCredsCredential(vc.vc)
+      : await verifyW3cCredential(vc.vc);
+
+    if (!verifyResult.verified) {
+      return {
+        failed: {
+          id: vc.vcId,
+          format: formatToString(vc.format),
+          error: verifyResult.error ?? 'Signature verification failed',
+          errorCode: 'SIGNATURE_INVALID',
+        },
+      };
+    }
+
+    // 2. Resolve VTJSC → CredentialSchema
+    const vtjscId = vc.credentialSchemaId;
+    let schema: CredentialSchema | undefined;
+    let schemaInfo: CredentialSchemaInfo | undefined;
+
+    if (vtjscId) {
+      schema = await resolveVtjscToSchema(vtjscId, indexer, ctx.currentBlock);
+      if (schema) {
+        schemaInfo = {
+          id: Number(schema.id),
+          jsonSchema: schema.json_schema,
+          ecosystemDid: await resolveEcosystemDid(schema.tr_id, indexer, ctx.currentBlock),
+          ecosystemAka: await resolveEcosystemAka(schema.tr_id, indexer, ctx.currentBlock),
+          issuerPermManagementMode: schema.issuer_perm_management_mode,
+        };
+      }
+    }
+
+    // 3. Determine ECS type from VTJSC URI
+    const ecsType = classifyEcsType(vtjscId);
+
+    // 4. Determine effective issuance time
+    let effectiveIssuanceTime: string | undefined;
+    let digestSri: string | undefined;
+
+    if (vc.format !== 'anoncreds' && vc.vc) {
+      try {
+        digestSri = await computeDigestSRI(vc.vc);
+        const digestResp = await indexer.getDigest(digestSri, ctx.currentBlock);
+        if (digestResp.digest) {
+          effectiveIssuanceTime = digestResp.digest.created;
+        }
+      } catch {
+        // Digest not found on-chain — use issuedAt from VC if available
+        effectiveIssuanceTime = extractIssuedAt(vc.vc);
+      }
+    } else {
+      // AnonCreds: use current time
+      effectiveIssuanceTime = new Date().toISOString();
+    }
+
+    // 5. Verify issuer has ISSUER permission at effective issuance time
+    let issuerPermission: Permission | undefined;
+    if (schema && vc.issuerDid) {
+      issuerPermission = await findIssuerPermission(
+        vc.issuerDid,
+        schema.id,
+        indexer,
+        ctx.currentBlock,
+      );
+    }
+
+    if (!issuerPermission) {
+      return {
+        failed: {
+          id: vc.vcId,
+          format: formatToString(vc.format),
+          error: `No active ISSUER permission found for issuer ${vc.issuerDid} on schema ${schema?.id ?? 'unknown'}`,
+          errorCode: 'ISSUER_NOT_AUTHORIZED',
+        },
+      };
+    }
+
+    // 6. Build permission chain
+    let permissionChain = schemaInfo
+      ? await buildPermissionChain(
+          issuerPermission,
+          {
+            issuerPermManagementMode: schemaInfo.issuerPermManagementMode,
+            ecosystemDid: schemaInfo.ecosystemDid,
+          },
+          indexer,
+          ctx.trustMemo,
+          ctx.currentBlock,
+        )
+      : [];
+
+    // 7. Enrich permission chain entries with trust deposit info
+    for (const entry of permissionChain) {
+      try {
+        const depositResp = await indexer.getTrustDepositByAccount(entry.did, ctx.currentBlock);
+        if (depositResp.trust_deposit) {
+          entry.deposit = depositResp.trust_deposit.amount;
+        }
+      } catch {
+        // Keep permission deposit
+      }
+    }
+
+    // 8. Extract claims from VC
+    const claims = extractClaims(vc.vc);
+
+    // 9. Determine result: VALID if ECS match + all checks pass, IGNORED if non-ECS
+    const result = ecsType !== null ? 'VALID' as const : 'IGNORED' as const;
+
+    return {
+      credential: {
+        result,
+        ecsType,
+        presentedBy,
+        issuedBy: vc.issuerDid,
+        id: vc.vcId,
+        type: extractType(vc.vc),
+        format: formatToString(vc.format),
+        issuedAt: extractIssuedAt(vc.vc),
+        validUntil: extractValidUntil(vc.vc),
+        digestSri,
+        effectiveIssuanceTime,
+        vtjscId,
+        claims,
+        schema: schemaInfo,
+        permissionChain,
+      },
+    };
+  } catch (err) {
+    return {
+      failed: {
+        id: vc.vcId,
+        format: formatToString(vc.format),
+        error: err instanceof Error ? err.message : String(err),
+        errorCode: 'EVALUATION_ERROR',
+      },
+    };
+  }
+}
+
+// --- Helpers ---
+
+async function resolveVtjscToSchema(
+  vtjscId: string,
+  indexer: IndexerClient,
+  atBlock?: number,
+): Promise<CredentialSchema | undefined> {
+  // The Indexer doesn't support filtering by json_schema directly,
+  // so we list all schemas and filter client-side.
+  // In production, this should be cached per trust registry.
+  try {
+    const resp = await indexer.listCredentialSchemas({}, atBlock);
+    return resp.credential_schemas.find((s) => s.json_schema === vtjscId);
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveEcosystemDid(
+  trId: string,
+  indexer: IndexerClient,
+  atBlock?: number,
+): Promise<string> {
+  try {
+    const resp = await indexer.getTrustRegistry(trId, atBlock);
+    return resp.trust_registry.did;
+  } catch {
+    return '';
+  }
+}
+
+async function resolveEcosystemAka(
+  trId: string,
+  indexer: IndexerClient,
+  atBlock?: number,
+): Promise<string | undefined> {
+  try {
+    const resp = await indexer.getTrustRegistry(trId, atBlock);
+    return resp.trust_registry.aka ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function findIssuerPermission(
+  issuerDid: string,
+  schemaId: string,
+  indexer: IndexerClient,
+  atBlock?: number,
+): Promise<Permission | undefined> {
+  try {
+    const resp = await indexer.listPermissions({
+      did: issuerDid,
+      schema_id: schemaId,
+      type: 'ISSUER',
+      only_valid: true,
+    }, atBlock);
+    return resp.permissions[0];
+  } catch {
+    return undefined;
+  }
+}
+
+export function classifyEcsType(vtjscId?: string): EcsType {
+  if (!vtjscId) return null;
+  for (const { pattern, ecsType } of ECS_TYPE_PATTERNS) {
+    if (pattern.test(vtjscId)) return ecsType;
+  }
+  return null;
+}
+
+function extractClaims(vc: Record<string, unknown>): Record<string, unknown> {
+  const subject = vc.credentialSubject;
+  if (typeof subject === 'object' && subject !== null) {
+    return { ...(subject as Record<string, unknown>) };
+  }
+  return {};
+}
+
+function extractType(vc: Record<string, unknown>): string {
+  const type = vc.type;
+  if (Array.isArray(type)) {
+    return type.find((t) => t !== 'VerifiableCredential') ?? 'VerifiableCredential';
+  }
+  return typeof type === 'string' ? type : 'VerifiableCredential';
+}
+
+function extractIssuedAt(vc: Record<string, unknown>): string | undefined {
+  const issuanceDate = vc.issuanceDate ?? vc.issued ?? vc.validFrom;
+  return typeof issuanceDate === 'string' ? issuanceDate : undefined;
+}
+
+function extractValidUntil(vc: Record<string, unknown>): string | undefined {
+  const expiry = vc.expirationDate ?? vc.validUntil;
+  return typeof expiry === 'string' ? expiry : undefined;
+}
+
+function formatToString(format: DereferencedVC['format']): string {
+  switch (format) {
+    case 'w3c-jsonld': return 'W3C_VTC';
+    case 'w3c-jwt': return 'W3C_VTC';
+    case 'anoncreds': return 'ANONCREDS';
+    default: return 'UNKNOWN';
+  }
+}

--- a/src/trust/index.ts
+++ b/src/trust/index.ts
@@ -1,0 +1,17 @@
+export { resolveTrust, createEvaluationContext } from './resolve-trust.js';
+export { evaluateCredential, classifyEcsType } from './evaluate-credential.js';
+export { evaluateVSRequirements } from './vs-requirements.js';
+export { buildPermissionChain } from './permission-chain.js';
+export { getCachedTrustResult, upsertTrustResult } from './trust-store.js';
+export type {
+  TrustResult,
+  TrustStatus,
+  CredentialEvaluation,
+  CredentialResultStatus,
+  FailedCredential,
+  PermissionChainEntry,
+  PermissionType,
+  EcsType,
+  CredentialSchemaInfo,
+  EvaluationContext,
+} from './types.js';

--- a/src/trust/permission-chain.ts
+++ b/src/trust/permission-chain.ts
@@ -1,0 +1,107 @@
+import type { IndexerClient } from '../indexer/client.js';
+import type { Permission } from '../indexer/types.js';
+import type { PermissionChainEntry, PermissionType, TrustResult } from './types.js';
+
+export async function buildPermissionChain(
+  issuerPermission: Permission,
+  schema: { issuerPermManagementMode: string; ecosystemDid: string },
+  indexer: IndexerClient,
+  trustMemo: Map<string, TrustResult>,
+  atBlock?: number,
+): Promise<PermissionChainEntry[]> {
+  const chain: PermissionChainEntry[] = [];
+
+  // 1. ISSUER entry
+  chain.push(
+    await buildChainEntry(issuerPermission, 'ISSUER', trustMemo),
+  );
+
+  // 2. ISSUER_GRANTOR (only if GRANTOR_VALIDATION mode)
+  if (schema.issuerPermManagementMode === 'GRANTOR_VALIDATION' && issuerPermission.validator_perm_id) {
+    try {
+      const grantorResp = await indexer.getPermission(issuerPermission.validator_perm_id, atBlock);
+      chain.push(
+        await buildChainEntry(grantorResp.permission, 'ISSUER_GRANTOR', trustMemo),
+      );
+    } catch {
+      // Grantor permission not found — chain is incomplete but we continue
+    }
+  }
+
+  // 3. ECOSYSTEM — find the ECOSYSTEM permission for this schema's ecosystem DID
+  try {
+    const ecosystemPerms = await indexer.listPermissions({
+      did: schema.ecosystemDid,
+      type: 'ECOSYSTEM',
+      only_valid: true,
+    }, atBlock);
+
+    const ecosystemPerm = ecosystemPerms.permissions[0];
+    if (ecosystemPerm) {
+      chain.push(
+        await buildChainEntry(ecosystemPerm, 'ECOSYSTEM', trustMemo),
+      );
+    }
+  } catch {
+    // Ecosystem permission not found
+  }
+
+  return chain;
+}
+
+async function buildChainEntry(
+  perm: Permission,
+  type: PermissionType,
+  trustMemo: Map<string, TrustResult>,
+): Promise<PermissionChainEntry> {
+  const entry: PermissionChainEntry = {
+    permissionId: Number(perm.id),
+    type,
+    did: perm.did,
+    didIsTrustedVS: false,
+    deposit: perm.deposit,
+    permState: perm.perm_state,
+    effectiveFrom: perm.effective || undefined,
+    effectiveUntil: perm.expiration || undefined,
+  };
+
+  // Check if this DID is a trusted VS from the memo cache
+  const cachedTrust = trustMemo.get(perm.did);
+  if (cachedTrust) {
+    entry.didIsTrustedVS = cachedTrust.trustStatus === 'TRUSTED';
+    // Derive serviceName, organizationName, countryCode from the participant's own ECS credentials
+    const serviceNameCred = cachedTrust.credentials.find(
+      (c) => c.ecsType === 'ECS-SERVICE' && c.result === 'VALID',
+    );
+    if (serviceNameCred?.claims) {
+      entry.serviceName = String(serviceNameCred.claims.name ?? '');
+    }
+
+    const orgCred = cachedTrust.credentials.find(
+      (c) => (c.ecsType === 'ECS-ORG' || c.ecsType === 'ECS-PERSONA') && c.result === 'VALID',
+    );
+    if (orgCred?.claims) {
+      entry.organizationName = String(orgCred.claims.name ?? '');
+      entry.countryCode = String(orgCred.claims.countryCode ?? '');
+      entry.legalJurisdiction = String(orgCred.claims.legalJurisdiction ?? '');
+    }
+  }
+
+  return entry;
+}
+
+export async function getTrustDepositForEntry(
+  entry: PermissionChainEntry,
+  indexer: IndexerClient,
+  atBlock?: number,
+): Promise<PermissionChainEntry> {
+  try {
+    const depositResp = await indexer.getTrustDepositByAccount(entry.did, atBlock);
+    if (depositResp.trust_deposit) {
+      entry.deposit = depositResp.trust_deposit.amount;
+    }
+  } catch {
+    // Deposit not found — keep the permission deposit
+  }
+  return entry;
+}

--- a/src/trust/resolve-trust.ts
+++ b/src/trust/resolve-trust.ts
@@ -1,0 +1,150 @@
+import type { IndexerClient } from '../indexer/client.js';
+import { resolveDID } from '../ssi/did-resolver.js';
+import { dereferenceAllVPs } from '../ssi/vp-dereferencer.js';
+import { evaluateCredential } from './evaluate-credential.js';
+import { evaluateVSRequirements } from './vs-requirements.js';
+import type {
+  TrustResult,
+  CredentialEvaluation,
+  FailedCredential,
+  EvaluationContext,
+} from './types.js';
+
+export async function resolveTrust(
+  did: string,
+  indexer: IndexerClient,
+  ctx: EvaluationContext,
+): Promise<TrustResult> {
+  // 1. Check in-memory memo
+  const memoized = ctx.trustMemo.get(did);
+  if (memoized) return memoized;
+
+  // 2. Cycle detection
+  if (ctx.visitedDids.has(did)) {
+    const circular: TrustResult = {
+      did,
+      trustStatus: 'UNTRUSTED',
+      production: false,
+      evaluatedAt: new Date().toISOString(),
+      evaluatedAtBlock: ctx.currentBlock,
+      expiresAt: computeExpiresAt(ctx.cacheTtlSeconds),
+      credentials: [],
+      failedCredentials: [{
+        id: did,
+        format: 'N/A',
+        error: 'Circular reference detected',
+        errorCode: 'CIRCULAR_REFERENCE',
+      }],
+    };
+    ctx.trustMemo.set(did, circular);
+    return circular;
+  }
+  ctx.visitedDids.add(did);
+
+  // 3. Resolve DID Document
+  const didResult = await resolveDID(did);
+  if (didResult.error || !didResult.result) {
+    const unresolvedResult: TrustResult = {
+      did,
+      trustStatus: 'UNTRUSTED',
+      production: false,
+      evaluatedAt: new Date().toISOString(),
+      evaluatedAtBlock: ctx.currentBlock,
+      expiresAt: computeExpiresAt(ctx.cacheTtlSeconds),
+      credentials: [],
+      failedCredentials: [{
+        id: did,
+        format: 'N/A',
+        error: didResult.error?.error ?? 'DID resolution failed',
+        errorCode: 'DID_RESOLUTION_FAILED',
+      }],
+    };
+    ctx.trustMemo.set(did, unresolvedResult);
+    return unresolvedResult;
+  }
+
+  const didDoc = didResult.result.didDocument;
+
+  // 4. Dereference VPs and extract VCs
+  const { vps, errors: vpErrors } = await dereferenceAllVPs(didDoc);
+
+  const credentials: CredentialEvaluation[] = [];
+  const failedCredentials: FailedCredential[] = [];
+
+  // Convert VP dereference errors to failed credentials
+  for (const vpErr of vpErrors) {
+    failedCredentials.push({
+      id: vpErr.resource,
+      uri: vpErr.resource,
+      format: 'UNKNOWN',
+      error: vpErr.error,
+      errorCode: 'VP_DEREFERENCE_FAILED',
+    });
+  }
+
+  // 5. Evaluate each credential from all VPs
+  for (const vp of vps) {
+    for (const vc of vp.credentials) {
+      const evalResult = await evaluateCredential(vc, did, indexer, ctx);
+      if (evalResult.credential) {
+        credentials.push(evalResult.credential);
+      }
+      if (evalResult.failed) {
+        failedCredentials.push(evalResult.failed);
+      }
+    }
+  }
+
+  // 6. Classify credentials
+  const validCredentials = credentials.filter((c) => c.result === 'VALID');
+
+  // 7. Evaluate VS-REQ-2/3/4
+  const trustStatus = await evaluateVSRequirements(
+    did,
+    validCredentials,
+    indexer,
+    ctx,
+    resolveTrust,
+  );
+
+  // 8. Derive production flag
+  const production = deriveProduction(validCredentials);
+
+  // 9. Build result
+  const result: TrustResult = {
+    did,
+    trustStatus,
+    production,
+    evaluatedAt: new Date().toISOString(),
+    evaluatedAtBlock: ctx.currentBlock,
+    expiresAt: computeExpiresAt(ctx.cacheTtlSeconds),
+    credentials,
+    failedCredentials,
+  };
+
+  ctx.trustMemo.set(did, result);
+  return result;
+}
+
+export function createEvaluationContext(
+  currentBlock: number,
+  cacheTtlSeconds: number,
+): EvaluationContext {
+  return {
+    visitedDids: new Set<string>(),
+    currentBlock,
+    cacheTtlSeconds,
+    trustMemo: new Map<string, TrustResult>(),
+  };
+}
+
+function deriveProduction(validCredentials: CredentialEvaluation[]): boolean {
+  // A DID is "production" if it has at least one VALID credential
+  // and no credential is explicitly marked as non-production / sandbox.
+  // For now: production = has any VALID ECS credential.
+  return validCredentials.some((c) => c.ecsType !== null);
+}
+
+function computeExpiresAt(ttlSeconds: number): string {
+  return new Date(Date.now() + ttlSeconds * 1000).toISOString();
+}

--- a/src/trust/trust-store.ts
+++ b/src/trust/trust-store.ts
@@ -1,0 +1,123 @@
+import { getPool } from '../db/index.js';
+import type { TrustResult, CredentialEvaluation } from './types.js';
+
+export async function getCachedTrustResult(did: string): Promise<TrustResult | null> {
+  const pool = getPool();
+  const row = await pool.query(
+    `SELECT did, trust_status, production, evaluated_at, evaluated_block, expires_at
+     FROM trust_results WHERE did = $1 AND expires_at > NOW()`,
+    [did],
+  );
+
+  if (row.rows.length === 0) return null;
+
+  const r = row.rows[0];
+
+  // Fetch associated credential results
+  const credRows = await pool.query(
+    `SELECT credential_id, result_status, ecs_type, schema_id, issuer_did,
+            presented_by, issued_by, perm_id, error_reason
+     FROM credential_results WHERE did = $1`,
+    [did],
+  );
+
+  const credentials: CredentialEvaluation[] = [];
+  for (const cr of credRows.rows) {
+    if (cr.result_status !== 'FAILED') {
+      credentials.push({
+        result: cr.result_status,
+        ecsType: cr.ecs_type ?? null,
+        presentedBy: cr.presented_by ?? '',
+        issuedBy: cr.issued_by ?? '',
+        id: cr.credential_id,
+        type: 'VerifiableTrustCredential',
+        format: 'W3C_VTC',
+        claims: {},
+        permissionChain: [],
+      });
+    }
+  }
+
+  return {
+    did: r.did,
+    trustStatus: r.trust_status,
+    production: r.production,
+    evaluatedAt: r.evaluated_at.toISOString(),
+    evaluatedAtBlock: Number(r.evaluated_block),
+    expiresAt: r.expires_at.toISOString(),
+    credentials,
+    failedCredentials: [],
+  };
+}
+
+export async function upsertTrustResult(result: TrustResult): Promise<void> {
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    // Upsert trust_results
+    await client.query(
+      `INSERT INTO trust_results (did, trust_status, production, evaluated_at, evaluated_block, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (did) DO UPDATE SET
+         trust_status = EXCLUDED.trust_status,
+         production = EXCLUDED.production,
+         evaluated_at = EXCLUDED.evaluated_at,
+         evaluated_block = EXCLUDED.evaluated_block,
+         expires_at = EXCLUDED.expires_at`,
+      [
+        result.did,
+        result.trustStatus,
+        result.production,
+        result.evaluatedAt,
+        result.evaluatedAtBlock,
+        result.expiresAt,
+      ],
+    );
+
+    // Delete old credential results for this DID
+    await client.query('DELETE FROM credential_results WHERE did = $1', [result.did]);
+
+    // Insert credential results
+    for (const cred of result.credentials) {
+      await client.query(
+        `INSERT INTO credential_results
+           (did, credential_id, result_status, ecs_type, schema_id, issuer_did, presented_by, issued_by, perm_id)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+        [
+          result.did,
+          cred.id,
+          cred.result,
+          cred.ecsType,
+          cred.schema?.id ?? null,
+          cred.issuedBy,
+          cred.presentedBy,
+          cred.issuedBy,
+          cred.permissionChain[0]?.permissionId ?? null,
+        ],
+      );
+    }
+
+    // Insert failed credentials
+    for (const failed of result.failedCredentials) {
+      await client.query(
+        `INSERT INTO credential_results
+           (did, credential_id, result_status, error_reason)
+         VALUES ($1, $2, 'FAILED', $3)
+         ON CONFLICT (did, credential_id) DO UPDATE SET
+           result_status = 'FAILED',
+           error_reason = EXCLUDED.error_reason`,
+        [result.did, failed.id, failed.error],
+      );
+    }
+
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/src/trust/types.ts
+++ b/src/trust/types.ts
@@ -1,0 +1,73 @@
+export type TrustStatus = 'TRUSTED' | 'PARTIAL' | 'UNTRUSTED';
+export type CredentialResultStatus = 'VALID' | 'IGNORED' | 'FAILED';
+export type EcsType = 'ECS-SERVICE' | 'ECS-ORG' | 'ECS-PERSONA' | 'ECS-UA' | null;
+export type PermissionType = 'ISSUER' | 'ISSUER_GRANTOR' | 'ECOSYSTEM' | 'VERIFIER' | 'VERIFIER_GRANTOR';
+
+export interface PermissionChainEntry {
+  permissionId: number;
+  type: PermissionType;
+  did: string;
+  didIsTrustedVS: boolean;
+  serviceName?: string;
+  organizationName?: string;
+  countryCode?: string;
+  legalJurisdiction?: string;
+  deposit: string;
+  permState: string;
+  effectiveFrom?: string;
+  effectiveUntil?: string;
+}
+
+export interface CredentialSchemaInfo {
+  id: number;
+  jsonSchema: string;
+  ecosystemDid: string;
+  ecosystemAka?: string;
+  issuerPermManagementMode: string;
+}
+
+export interface CredentialEvaluation {
+  result: CredentialResultStatus;
+  ecsType: EcsType;
+  presentedBy: string;
+  issuedBy: string;
+  id: string;
+  type: string;
+  format: string;
+  issuedAt?: string;
+  validUntil?: string;
+  digestSri?: string;
+  effectiveIssuanceTime?: string;
+  vtjscId?: string;
+  claims: Record<string, unknown>;
+  schema?: CredentialSchemaInfo;
+  permissionChain: PermissionChainEntry[];
+  error?: string;
+  errorCode?: string;
+}
+
+export interface FailedCredential {
+  id: string;
+  uri?: string;
+  format: string;
+  error: string;
+  errorCode: string;
+}
+
+export interface TrustResult {
+  did: string;
+  trustStatus: TrustStatus;
+  production: boolean;
+  evaluatedAt: string;
+  evaluatedAtBlock: number;
+  expiresAt: string;
+  credentials: CredentialEvaluation[];
+  failedCredentials: FailedCredential[];
+}
+
+export interface EvaluationContext {
+  visitedDids: Set<string>;
+  currentBlock: number;
+  cacheTtlSeconds: number;
+  trustMemo: Map<string, TrustResult>;
+}

--- a/src/trust/vs-requirements.ts
+++ b/src/trust/vs-requirements.ts
@@ -1,0 +1,64 @@
+import type { IndexerClient } from '../indexer/client.js';
+import type { CredentialEvaluation, EvaluationContext, TrustResult, TrustStatus } from './types.js';
+
+/**
+ * Evaluate VS-REQ-2/3/4 requirements.
+ *
+ * Groups valid credentials by ecosystem, then for each ecosystem:
+ * - Checks for ECS-SERVICE presence (VS-REQ-2)
+ * - VS-REQ-3: if self-issued service cred → VS must also present ECS-ORG or ECS-PERSONA
+ * - VS-REQ-4: if externally issued service cred → issuer's DID must present ECS-ORG or ECS-PERSONA
+ */
+export async function evaluateVSRequirements(
+  did: string,
+  validCredentials: CredentialEvaluation[],
+  indexer: IndexerClient,
+  ctx: EvaluationContext,
+  resolveTrustFn: (did: string, indexer: IndexerClient, ctx: EvaluationContext) => Promise<TrustResult>,
+): Promise<TrustStatus> {
+  // Group valid credentials by ecosystem
+  const byEcosystem = new Map<string, CredentialEvaluation[]>();
+  for (const cred of validCredentials) {
+    const ecosystemDid = cred.schema?.ecosystemDid;
+    if (!ecosystemDid) continue;
+
+    const existing = byEcosystem.get(ecosystemDid) ?? [];
+    existing.push(cred);
+    byEcosystem.set(ecosystemDid, existing);
+  }
+
+  if (byEcosystem.size === 0) return 'UNTRUSTED';
+
+  let satisfiedEcosystems = 0;
+  const totalEcosystems = byEcosystem.size;
+
+  for (const [, creds] of byEcosystem) {
+    const serviceCred = creds.find((c) => c.ecsType === 'ECS-SERVICE');
+    if (!serviceCred) continue;
+
+    // VS-REQ-3: self-issued → VS must also present ECS-ORG or ECS-PERSONA
+    if (serviceCred.issuedBy === did) {
+      const hasOrgOrPersona = creds.some(
+        (c) =>
+          (c.ecsType === 'ECS-ORG' || c.ecsType === 'ECS-PERSONA') &&
+          c.presentedBy === did,
+      );
+      if (hasOrgOrPersona) satisfiedEcosystems++;
+      continue;
+    }
+
+    // VS-REQ-4: issued by another DID → issuer's DID must present ECS-ORG or ECS-PERSONA
+    const issuerResult = await resolveTrustFn(serviceCred.issuedBy, indexer, ctx);
+    const issuerHasOrgOrPersona = issuerResult.credentials.some(
+      (c) =>
+        (c.ecsType === 'ECS-ORG' || c.ecsType === 'ECS-PERSONA') &&
+        c.presentedBy === serviceCred.issuedBy &&
+        c.result === 'VALID',
+    );
+    if (issuerHasOrgOrPersona) satisfiedEcosystems++;
+  }
+
+  if (satisfiedEcosystems === totalEcosystems && totalEcosystems > 0) return 'TRUSTED';
+  if (satisfiedEcosystems > 0) return 'PARTIAL';
+  return 'UNTRUSTED';
+}


### PR DESCRIPTION
## Summary

Implements the core `resolveTrust` algorithm for **Trust Question 1** as specified in `trust-resolution.md` and `implementation-plan.md`.

### New files

| File | Description |
|------|-------------|
| `src/trust/types.ts` | `TrustResult`, `CredentialEvaluation`, `PermissionChainEntry`, `EcsType`, `EvaluationContext` types |
| `src/trust/resolve-trust.ts` | Main `resolveTrust` function with cycle detection (visited set), memoization (trust memo), DID resolution → VP dereference → VC evaluation pipeline |
| `src/trust/evaluate-credential.ts` | Per-credential evaluation: signature verification, VTJSC→CredentialSchema resolution, ECS type classification, effective issuance time via digestSRI, issuer permission lookup |
| `src/trust/vs-requirements.ts` | VS-REQ-2/3/4 logic: groups credentials by ecosystem, checks self-issued (REQ-3) vs externally-issued (REQ-4) service credentials |
| `src/trust/permission-chain.ts` | Builds ISSUER → ISSUER_GRANTOR → ECOSYSTEM permission chain, enriches with trust deposit and ECS-derived metadata |
| `src/trust/trust-store.ts` | PG read/write for `trust_results` + `credential_results` tables (upsert with transaction) |
| `src/trust/index.ts` | Barrel exports |
| `test/trust-resolve.test.ts` | 18 unit tests covering `classifyEcsType`, `evaluateVSRequirements` (VS-REQ-3, VS-REQ-4, PARTIAL), cycle detection, context creation |

### Algorithm flow

1. **Memo check** — return cached result if already evaluated in this pass
2. **Cycle detection** — if DID already in visited set, return UNTRUSTED
3. **Resolve DID Document** via Credo agent (cached in Redis)
4. **Dereference all LinkedVerifiablePresentation VPs** in parallel
5. **Evaluate each credential**: verify signature → resolve VTJSC → classify ECS type → compute digestSRI → check issuer permission → build permission chain
6. **Evaluate VS requirements** per ecosystem (VS-REQ-2/3/4)
7. **Derive production flag** and build final `TrustResult`

### Notes

- Signature verification is currently **stubbed** (returns `verified: false` with a TODO message) — will be implemented when Credo agent integration is complete
- VTJSC→CredentialSchema mapping uses client-side filtering since the Indexer API doesn't expose a `json_schema` query parameter — should be optimized with caching in production
- All 64 tests pass (18 new + 46 existing), TypeScript compiles clean

Closes #17