### PR TITLE
feat: add Q1 REST endpoint GET /v1/trust/resolve

### DIFF
--- a/migrations/002_add_full_result_json.sql
+++ b/migrations/002_add_full_result_json.sql
@@ -1,0 +1,6 @@
+-- Store the full TrustResult JSON for detail=full queries
+ALTER TABLE trust_results ADD COLUMN full_result_json JSONB;
+
+-- GIN index for potential future queries on the JSON structure
+CREATE INDEX idx_trust_full_result ON trust_results USING GIN (full_result_json)
+  WHERE full_result_json IS NOT NULL;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import { loadConfig } from './config/index.js';
 import { loadVprAllowlist } from './config/vpr-allowlist.js';
+import { registerQ1Route } from './routes/q1-resolve.js';
 
 async function main(): Promise<void> {
   const config = loadConfig();
@@ -19,6 +20,8 @@ async function main(): Promise<void> {
       vprs: allowlist.vprs.map((vpr) => vpr.id),
     };
   });
+
+  await registerQ1Route(server);
 
   await server.listen({ port: config.PORT, host: '0.0.0.0' });
   server.log.info(

--- a/src/routes/q1-resolve.ts
+++ b/src/routes/q1-resolve.ts
@@ -1,0 +1,60 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { getSummaryTrustResult, getFullTrustResult } from '../trust/trust-store.js';
+
+interface Q1QueryString {
+  did?: string;
+  detail?: string;
+}
+
+export async function registerQ1Route(server: FastifyInstance): Promise<void> {
+  server.get<{ Querystring: Q1QueryString }>(
+    '/v1/trust/resolve',
+    async (request: FastifyRequest<{ Querystring: Q1QueryString }>, reply: FastifyReply) => {
+      const { did, detail } = request.query;
+
+      // Validate required parameter
+      if (!did || typeof did !== 'string' || !did.startsWith('did:')) {
+        return reply.status(400).send({
+          error: 'Bad Request',
+          message: 'Missing or invalid "did" query parameter. Must be a valid DID.',
+        });
+      }
+
+      // Validate detail parameter
+      const detailMode = detail ?? 'summary';
+      if (detailMode !== 'summary' && detailMode !== 'full') {
+        return reply.status(400).send({
+          error: 'Bad Request',
+          message: 'Invalid "detail" query parameter. Must be "summary" or "full".',
+        });
+      }
+
+      if (detailMode === 'summary') {
+        const summary = await getSummaryTrustResult(did);
+        if (!summary) {
+          return reply.status(404).send({
+            error: 'Not Found',
+            message: `No trust evaluation found for DID: ${did}`,
+          });
+        }
+
+        reply.header('X-Evaluated-At-Block', String(summary.evaluatedAtBlock));
+        reply.header('X-Cache-Hit', 'true');
+        return reply.send(summary);
+      }
+
+      // detail=full
+      const full = await getFullTrustResult(did);
+      if (!full) {
+        return reply.status(404).send({
+          error: 'Not Found',
+          message: `No trust evaluation found for DID: ${did}`,
+        });
+      }
+
+      reply.header('X-Evaluated-At-Block', String(full.evaluatedAtBlock));
+      reply.header('X-Cache-Hit', 'true');
+      return reply.send(full);
+    },
+  );
+}

--- a/src/trust/index.ts
+++ b/src/trust/index.ts
@@ -2,7 +2,8 @@ export { resolveTrust, createEvaluationContext } from './resolve-trust.js';
 export { evaluateCredential, classifyEcsType } from './evaluate-credential.js';
 export { evaluateVSRequirements } from './vs-requirements.js';
 export { buildPermissionChain } from './permission-chain.js';
-export { getCachedTrustResult, upsertTrustResult } from './trust-store.js';
+export { getSummaryTrustResult, getFullTrustResult, upsertTrustResult } from './trust-store.js';
+export type { TrustResultSummary } from './trust-store.js';
 export type {
   TrustResult,
   TrustStatus,

--- a/test/q1-resolve.test.ts
+++ b/test/q1-resolve.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import { registerQ1Route } from '../src/routes/q1-resolve.js';
+
+// Mock the trust-store module
+vi.mock('../src/trust/trust-store.js', () => ({
+  getSummaryTrustResult: vi.fn(),
+  getFullTrustResult: vi.fn(),
+}));
+
+import { getSummaryTrustResult, getFullTrustResult } from '../src/trust/trust-store.js';
+
+const mockGetSummary = vi.mocked(getSummaryTrustResult);
+const mockGetFull = vi.mocked(getFullTrustResult);
+
+async function buildApp() {
+  const app = Fastify();
+  await registerQ1Route(app);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// --- Parameter validation ---
+
+describe('Q1 /v1/trust/resolve — parameter validation', () => {
+  it('returns 400 when did is missing', async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/v1/trust/resolve' });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toMatch(/Missing or invalid "did"/);
+  });
+
+  it('returns 400 when did does not start with did:', async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: 'GET', url: '/v1/trust/resolve?did=notadid' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when detail is invalid', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/resolve?did=did:web:example.com&detail=invalid',
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toMatch(/Invalid "detail"/);
+  });
+});
+
+// --- Summary mode ---
+
+describe('Q1 /v1/trust/resolve — summary mode', () => {
+  it('returns 404 when DID not found', async () => {
+    mockGetSummary.mockResolvedValue(null);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/resolve?did=did:web:unknown.example.com',
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().message).toMatch(/No trust evaluation found/);
+  });
+
+  it('returns summary result with correct headers', async () => {
+    mockGetSummary.mockResolvedValue({
+      did: 'did:web:acme.example.com',
+      trustStatus: 'TRUSTED',
+      production: true,
+      evaluatedAt: '2026-02-13T10:00:00.000Z',
+      evaluatedAtBlock: 1500000,
+      expiresAt: '2026-02-14T10:00:00.000Z',
+    });
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/resolve?did=did:web:acme.example.com',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.did).toBe('did:web:acme.example.com');
+    expect(body.trustStatus).toBe('TRUSTED');
+    expect(body.production).toBe(true);
+    expect(body.evaluatedAtBlock).toBe(1500000);
+    expect(res.headers['x-evaluated-at-block']).toBe('1500000');
+    expect(res.headers['x-cache-hit']).toBe('true');
+  });
+
+  it('defaults to summary when detail is not specified', async () => {
+    mockGetSummary.mockResolvedValue({
+      did: 'did:web:test.example.com',
+      trustStatus: 'UNTRUSTED',
+      production: false,
+      evaluatedAt: '2026-02-13T10:00:00.000Z',
+      evaluatedAtBlock: 100,
+      expiresAt: '2026-02-14T10:00:00.000Z',
+    });
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/resolve?did=did:web:test.example.com',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockGetSummary).toHaveBeenCalledWith('did:web:test.example.com');
+    expect(mockGetFull).not.toHaveBeenCalled();
+  });
+
+  it('calls getSummaryTrustResult for detail=summary', async () => {
+    mockGetSummary.mockResolvedValue({
+      did: 'did:web:test.example.com',
+      trustStatus: 'PARTIAL',
+      production: false,
+      evaluatedAt: '2026-02-13T10:00:00.000Z',
+      evaluatedAtBlock: 200,
+      expiresAt: '2026-02-14T10:00:00.000Z',
+    });
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/resolve?did=did:web:test.example.com&detail=summary',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockGetSummary).toHaveBeenCalledWith('did:web:test.example.com');
+  });
+});
+
+// --- Full mode ---
+
+describe('Q1 /v1/trust/resolve — full mode', () => {
+  it('returns 404 when DID not found in full mode', async () => {
+    mockGetFull.mockResolvedValue(null);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/resolve?did=did:web:unknown.example.com&detail=full',
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns full result with credentials and headers', async () => {
+    mockGetFull.mockResolvedValue({
+      did: 'did:web:acme.example.com',
+      trustStatus: 'TRUSTED',
+      production: true,
+      evaluatedAt: '2026-02-13T10:00:00.000Z',
+      evaluatedAtBlock: 1500000,
+      expiresAt: '2026-02-14T10:00:00.000Z',
+      credentials: [
+        {
+          result: 'VALID',
+          ecsType: 'ECS-SERVICE',
+          presentedBy: 'did:web:acme.example.com',
+          issuedBy: 'did:web:acme.example.com',
+          id: 'urn:uuid:test',
+          type: 'VerifiableTrustCredential',
+          format: 'W3C_VTC',
+          claims: { name: 'Acme Insurance Portal' },
+          permissionChain: [
+            {
+              permissionId: 142,
+              type: 'ISSUER',
+              did: 'did:web:acme.example.com',
+              didIsTrustedVS: true,
+              deposit: '5000000uvna',
+              permState: 'ACTIVE',
+            },
+          ],
+        },
+      ],
+      failedCredentials: [],
+    });
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/resolve?did=did:web:acme.example.com&detail=full',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.credentials).toHaveLength(1);
+    expect(body.credentials[0].ecsType).toBe('ECS-SERVICE');
+    expect(body.credentials[0].claims.name).toBe('Acme Insurance Portal');
+    expect(body.credentials[0].permissionChain).toHaveLength(1);
+    expect(res.headers['x-evaluated-at-block']).toBe('1500000');
+    expect(res.headers['x-cache-hit']).toBe('true');
+  });
+
+  it('calls getFullTrustResult for detail=full', async () => {
+    mockGetFull.mockResolvedValue({
+      did: 'did:web:test.example.com',
+      trustStatus: 'UNTRUSTED',
+      production: false,
+      evaluatedAt: '2026-02-13T10:00:00.000Z',
+      evaluatedAtBlock: 300,
+      expiresAt: '2026-02-14T10:00:00.000Z',
+      credentials: [],
+      failedCredentials: [],
+    });
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/resolve?did=did:web:test.example.com&detail=full',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockGetFull).toHaveBeenCalledWith('did:web:test.example.com');
+    expect(mockGetSummary).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Q1 REST endpoint for serving pre-computed trust evaluation results from PostgreSQL.

### Endpoint

```
GET /v1/trust/resolve?did=...&detail=summary|full
```

### Parameters
- **`did`** (required) — the DID to query
- **`detail`** (optional, default: `summary`) — `summary` or `full`

### Behavior
- **`detail=summary`** — returns `{ did, trustStatus, production, evaluatedAt, evaluatedAtBlock, expiresAt }` from scalar PG columns (<1ms target)
- **`detail=full`** — returns complete `TrustResult` with credentials, claims, and permission chains from JSONB column (<5ms target)
- **404** when DID not found or evaluation expired
- **400** for missing/invalid parameters

### Response headers
- `X-Evaluated-At-Block` — block height at evaluation time
- `X-Cache-Hit: true` — always true (pre-computed results)

### New/changed files

| File | Description |
|------|-------------|
| `src/routes/q1-resolve.ts` | Route handler with parameter validation, summary/full dispatch |
| `migrations/002_add_full_result_json.sql` | Adds `full_result_json JSONB` column + GIN index to `trust_results` |
| `src/trust/trust-store.ts` | Split into `getSummaryTrustResult` (scalar) + `getFullTrustResult` (JSONB); `upsertTrustResult` now stores full JSON |
| `src/trust/index.ts` | Updated barrel exports |
| `src/index.ts` | Registers Q1 route via `registerQ1Route(server)` |
| `test/q1-resolve.test.ts` | 10 tests: validation (3), summary mode (4), full mode (3) |

### Test results
- 74 tests pass (10 new + 64 existing)
- TypeScript compiles clean

Closes #18