### PR TITLE
feat: add Q2 endpoint GET /v1/trust/issuer-authorization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import Fastify from 'fastify';
 import { loadConfig } from './config/index.js';
 import { loadVprAllowlist } from './config/vpr-allowlist.js';
 import { registerQ1Route } from './routes/q1-resolve.js';
+import { createQ2Route } from './routes/q2-issuer-auth.js';
+import { IndexerClient } from './indexer/client.js';
 
 async function main(): Promise<void> {
   const config = loadConfig();
@@ -22,6 +24,10 @@ async function main(): Promise<void> {
   });
 
   await registerQ1Route(server);
+
+  // Q2+ endpoints need IndexerClient
+  const indexer = new IndexerClient(allowlist.vprs[0]?.indexerUrl ?? 'http://localhost:3001');
+  await createQ2Route(indexer)(server);
 
   await server.listen({ port: config.PORT, host: '0.0.0.0' });
   server.log.info(

--- a/src/indexer/types.ts
+++ b/src/indexer/types.ts
@@ -111,6 +111,7 @@ export interface Permission {
   modified: string;
   effective: string;
   expiration: string | null;
+  effective_until?: string | null;
   revoked: string | null;
   slashed: string | null;
   repaid: string | null;
@@ -119,6 +120,11 @@ export interface Permission {
   vp_state: string;
   perm_state: string;
   validator_perm_id: string | null;
+  issuance_fees?: string;
+  verification_fees?: string;
+  validation_fees?: string;
+  issuance_fee_discount?: string;
+  verification_fee_discount?: string;
   issued: number;
   verified: number;
   ecosystem_slash_events: number;
@@ -160,7 +166,7 @@ export interface PermissionSessionListResponse {
 }
 
 export interface BeneficiaryResponse {
-  beneficiaries: unknown;
+  permissions: Permission[];
 }
 
 export interface TrustDeposit {
@@ -229,6 +235,7 @@ export interface ListPermissionsParams {
 
 export interface ListCredentialSchemasParams {
   tr_id?: string;
+  json_schema?: string;
   only_active?: boolean;
   issuer_perm_management_mode?: string;
   verifier_perm_management_mode?: string;

--- a/src/routes/q2-issuer-auth.ts
+++ b/src/routes/q2-issuer-auth.ts
@@ -1,0 +1,264 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { IndexerClient } from '../indexer/client.js';
+import type { Permission } from '../indexer/types.js';
+import { IndexerError } from '../indexer/errors.js';
+
+interface Q2QueryString {
+  did?: string;
+  vtjscId?: string;
+  sessionId?: string;
+  at?: string;
+}
+
+export function createQ2Route(indexer: IndexerClient) {
+  return async function registerQ2Route(server: FastifyInstance): Promise<void> {
+    server.get<{ Querystring: Q2QueryString }>(
+      '/v1/trust/issuer-authorization',
+      async (request: FastifyRequest<{ Querystring: Q2QueryString }>, reply: FastifyReply) => {
+        const { did, vtjscId, sessionId, at } = request.query;
+
+        // --- Parameter validation ---
+        if (!did || typeof did !== 'string' || !did.startsWith('did:')) {
+          return reply.status(400).send({
+            error: 'Bad Request',
+            message: 'Missing or invalid "did" query parameter. Must be a valid DID.',
+          });
+        }
+
+        if (!vtjscId || typeof vtjscId !== 'string') {
+          return reply.status(400).send({
+            error: 'Bad Request',
+            message: 'Missing or invalid "vtjscId" query parameter.',
+          });
+        }
+
+        // Parse optional block height
+        const atBlock = parseAtParam(at);
+
+        // --- 1. Map vtjscId \u2192 CredentialSchema ---
+        let schemaId: string;
+        try {
+          const schemas = await indexer.listCredentialSchemas({ json_schema: vtjscId }, atBlock);
+          const match = schemas.credential_schemas.find((s) => s.json_schema === vtjscId);
+          if (!match) {
+            return reply.status(404).send({
+              error: 'Not Found',
+              message: `No CredentialSchema found for VTJSC: ${vtjscId}`,
+            });
+          }
+          schemaId = match.id;
+        } catch (err) {
+          if (err instanceof IndexerError && err.statusCode === 404) {
+            return reply.status(404).send({
+              error: 'Not Found',
+              message: `No CredentialSchema found for VTJSC: ${vtjscId}`,
+            });
+          }
+          throw err;
+        }
+
+        // --- 2. Find active ISSUER permission ---
+        const permResp = await indexer.listPermissions(
+          { did, schema_id: schemaId, type: 'ISSUER', only_valid: true },
+          atBlock,
+        );
+
+        const issuerPerm = permResp.permissions.find((p) => p.perm_state === 'ACTIVE');
+
+        const now = new Date().toISOString();
+        const blockHeight = atBlock ?? (await indexer.getBlockHeight()).height;
+
+        if (!issuerPerm) {
+          return reply.send({
+            did,
+            vtjscId,
+            authorized: false,
+            evaluatedAt: now,
+            evaluatedAtBlock: blockHeight,
+            reason: `No active ISSUER permission found for DID on schema ${schemaId} (VTJSC: ${vtjscId})`,
+          });
+        }
+
+        // --- 3. Build permission chain (on-chain facts only) ---
+        const permissionChain = await buildOnChainPermissionChain(indexer, issuerPerm, atBlock);
+
+        // --- 4. Compute fees via findBeneficiaries ---
+        const feeResult = await computeFees(indexer, issuerPerm, atBlock);
+
+        // --- 5. Fee/session handling ---
+        if (feeResult.required && !sessionId) {
+          return reply.status(402).send({
+            authorized: false,
+            did,
+            vtjscId,
+            evaluatedAt: now,
+            evaluatedAtBlock: blockHeight,
+            reason:
+              'Payment required. Issuance fees are enabled for this schema but no sessionId was provided. The issuer must create a PermissionSession (MOD-PERM-MSG-10) and re-query with the sessionId.',
+            fees: feeResult,
+          });
+        }
+
+        // --- 6. Session verification (if provided) ---
+        let session: Record<string, unknown> | undefined;
+        if (sessionId) {
+          try {
+            const sessResp = await indexer.getPermissionSession(sessionId, atBlock);
+            const sess = sessResp.permission_session;
+
+            // Verify session references the correct issuer permission
+            const matchesIssuer = sess.records.some(
+              (r) => r.issuer_perm_id === issuerPerm.id,
+            );
+
+            session = {
+              id: sess.id,
+              paid: matchesIssuer,
+              issuerPermId: Number(issuerPerm.id),
+              agentPermId: Number(sess.agent_perm_id),
+              walletAgentPermId: sess.records[0]?.wallet_agent_perm_id
+                ? Number(sess.records[0].wallet_agent_perm_id)
+                : null,
+              created: sess.created,
+            };
+          } catch (err) {
+            if (err instanceof IndexerError && err.statusCode === 404) {
+              return reply.status(400).send({
+                error: 'Bad Request',
+                message: `PermissionSession not found: ${sessionId}`,
+              });
+            }
+            throw err;
+          }
+        }
+
+        // --- 7. Build response ---
+        const response: Record<string, unknown> = {
+          did,
+          vtjscId,
+          authorized: true,
+          evaluatedAt: now,
+          evaluatedAtBlock: blockHeight,
+          permission: {
+            id: Number(issuerPerm.id),
+            type: issuerPerm.type,
+            schemaId: Number(issuerPerm.schema_id),
+            did: issuerPerm.did,
+            deposit: issuerPerm.deposit,
+            permState: issuerPerm.perm_state,
+            effectiveFrom: issuerPerm.effective,
+            effectiveUntil: issuerPerm.effective_until ?? issuerPerm.expiration,
+            issuanceFeeDiscount: issuerPerm.issuance_fee_discount ?? '0',
+          },
+          fees: feeResult,
+          permissionChain,
+        };
+
+        if (session) {
+          response.session = session;
+        }
+
+        reply.header('X-Evaluated-At-Block', String(blockHeight));
+        return reply.send(response);
+      },
+    );
+  };
+}
+
+async function buildOnChainPermissionChain(
+  indexer: IndexerClient,
+  issuerPerm: Permission,
+  atBlock?: number,
+): Promise<Array<Record<string, unknown>>> {
+  const chain: Array<Record<string, unknown>> = [];
+
+  // ISSUER entry
+  chain.push({
+    permissionId: Number(issuerPerm.id),
+    type: issuerPerm.type,
+    did: issuerPerm.did,
+    deposit: issuerPerm.deposit,
+    permState: issuerPerm.perm_state,
+  });
+
+  // Walk to parent: ISSUER_GRANTOR (if validator_perm_id set)
+  if (issuerPerm.validator_perm_id) {
+    try {
+      const grantorResp = await indexer.getPermission(issuerPerm.validator_perm_id, atBlock);
+      const grantor = grantorResp.permission;
+      chain.push({
+        permissionId: Number(grantor.id),
+        type: grantor.type,
+        did: grantor.did,
+        deposit: grantor.deposit,
+        permState: grantor.perm_state,
+      });
+
+      // Walk to ECOSYSTEM
+      if (grantor.validator_perm_id) {
+        const ecoResp = await indexer.getPermission(grantor.validator_perm_id, atBlock);
+        const eco = ecoResp.permission;
+        chain.push({
+          permissionId: Number(eco.id),
+          type: eco.type,
+          did: eco.did,
+          deposit: eco.deposit,
+          permState: eco.perm_state,
+        });
+      }
+    } catch {
+      // Chain may be incomplete \u2014 that's acceptable
+    }
+  }
+
+  return chain;
+}
+
+async function computeFees(
+  indexer: IndexerClient,
+  issuerPerm: Permission,
+  atBlock?: number,
+): Promise<Record<string, unknown>> {
+  try {
+    const beneResp = await indexer.findBeneficiaries(issuerPerm.id, '0', atBlock);
+    const beneficiaries = beneResp.permissions.map((p) => ({
+      permissionId: Number(p.id),
+      type: p.type,
+      issuanceFees: p.issuance_fees ?? '0',
+    }));
+
+    const totalFees = beneficiaries.reduce((sum, b) => {
+      const feeStr = b.issuanceFees.replace(/[^0-9]/g, '');
+      return sum + (Number(feeStr) || 0);
+    }, 0);
+
+    // Check discount
+    const discount = Number(issuerPerm.issuance_fee_discount ?? '0');
+    const effectiveTotal = discount >= 1 ? 0 : totalFees;
+
+    if (effectiveTotal === 0) {
+      return {
+        required: false,
+        note: 'All issuance fees are zero or fully discounted (issuanceFeeDiscount=1). No PermissionSession required for fee payment.',
+      };
+    }
+
+    return {
+      required: true,
+      pricingAssetType: 'COIN',
+      pricingAsset: 'uvna',
+      totalBeneficiaryFees: `${effectiveTotal}uvna`,
+      beneficiaries,
+    };
+  } catch {
+    // If beneficiary lookup fails, assume no fees
+    return { required: false };
+  }
+}
+
+function parseAtParam(at?: string): number | undefined {
+  if (!at) return undefined;
+  const num = Number(at);
+  if (!Number.isNaN(num) && Number.isInteger(num) && num > 0) return num;
+  return undefined;
+}

--- a/test/q2-issuer-auth.test.ts
+++ b/test/q2-issuer-auth.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import { createQ2Route } from '../src/routes/q2-issuer-auth.js';
+import { IndexerError } from '../src/indexer/errors.js';
+
+function mockIndexer(overrides: Record<string, unknown> = {}) {
+  return {
+    listCredentialSchemas: vi.fn().mockResolvedValue({
+      credential_schemas: [
+        { id: '7', json_schema: 'https://example.com/schemas/regulated-insurer/v1', tr_id: '1' },
+      ],
+    }),
+    listPermissions: vi.fn().mockResolvedValue({
+      permissions: [
+        {
+          id: '142',
+          schema_id: '7',
+          type: 'ISSUER',
+          grantee: 'verana1abc',
+          did: 'did:web:ca-doi.gov.example.com',
+          created: '2025-01-01T00:00:00Z',
+          modified: '2025-01-01T00:00:00Z',
+          effective: '2025-01-01T00:00:00Z',
+          expiration: '2027-01-01T00:00:00Z',
+          effective_until: '2027-01-01T00:00:00Z',
+          revoked: null,
+          slashed: null,
+          repaid: null,
+          deposit: '5000000uvna',
+          country: 'US',
+          vp_state: 'VALIDATED',
+          perm_state: 'ACTIVE',
+          validator_perm_id: '50',
+          issuance_fees: '500000uvna',
+          issuance_fee_discount: '0',
+          issued: 0,
+          verified: 0,
+          ecosystem_slash_events: 0,
+          ecosystem_slashed_amount: '0',
+          network_slash_events: 0,
+          network_slashed_amount: '0',
+        },
+      ],
+    }),
+    getPermission: vi.fn().mockImplementation((id: string) => {
+      if (id === '50') {
+        return Promise.resolve({
+          permission: {
+            id: '50', type: 'ISSUER_GRANTOR', did: 'did:web:naic.example.com',
+            deposit: '20000000uvna', perm_state: 'ACTIVE', validator_perm_id: '7',
+            schema_id: '7', grantee: 'verana1xyz',
+          },
+        });
+      }
+      if (id === '7') {
+        return Promise.resolve({
+          permission: {
+            id: '7', type: 'ECOSYSTEM', did: 'did:web:insurance-trust.example.com',
+            deposit: '50000000uvna', perm_state: 'ACTIVE', validator_perm_id: null,
+            schema_id: '7', grantee: 'verana1eco',
+          },
+        });
+      }
+      throw new IndexerError('Not found', 404, 'NOT_FOUND');
+    }),
+    findBeneficiaries: vi.fn().mockResolvedValue({
+      permissions: [
+        { id: '142', type: 'ISSUER', issuance_fees: '500000uvna' },
+        { id: '50', type: 'ISSUER_GRANTOR', issuance_fees: '500000uvna' },
+        { id: '7', type: 'ECOSYSTEM', issuance_fees: '1000000uvna' },
+      ],
+    }),
+    getBlockHeight: vi.fn().mockResolvedValue({ height: 1500000 }),
+    getPermissionSession: vi.fn().mockResolvedValue({
+      permission_session: {
+        id: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
+        authority: 'verana1abc',
+        vs_operator: 'verana1op',
+        agent_perm_id: '88',
+        created: '2026-02-13T09:55:00Z',
+        modified: '2026-02-13T09:55:00Z',
+        records: [
+          { issuer_perm_id: '142', verifier_perm_id: '0', wallet_agent_perm_id: '92' },
+        ],
+      },
+    }),
+    ...overrides,
+  } as any;
+}
+
+async function buildApp(indexer: any) {
+  const app = Fastify();
+  await createQ2Route(indexer)(app);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// --- Parameter validation ---
+
+describe('Q2 /v1/trust/issuer-authorization \u2014 parameter validation', () => {
+  it('returns 400 when did is missing', async () => {
+    const app = await buildApp(mockIndexer());
+    const res = await app.inject({ method: 'GET', url: '/v1/trust/issuer-authorization' });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toMatch(/Missing or invalid "did"/);
+  });
+
+  it('returns 400 when did does not start with did:', async () => {
+    const app = await buildApp(mockIndexer());
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/issuer-authorization?did=notadid&vtjscId=https://example.com/schema',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when vtjscId is missing', async () => {
+    const app = await buildApp(mockIndexer());
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/issuer-authorization?did=did:web:test.example.com',
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toMatch(/Missing or invalid "vtjscId"/);
+  });
+});
+
+// --- Schema not found ---
+
+describe('Q2 /v1/trust/issuer-authorization \u2014 schema lookup', () => {
+  it('returns 404 when schema not found', async () => {
+    const idx = mockIndexer({
+      listCredentialSchemas: vi.fn().mockResolvedValue({ credential_schemas: [] }),
+    });
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/issuer-authorization?did=did:web:test.example.com&vtjscId=https://unknown.example.com/schema',
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().message).toMatch(/No CredentialSchema found/);
+  });
+});
+
+// --- Not authorized ---
+
+describe('Q2 /v1/trust/issuer-authorization \u2014 not authorized', () => {
+  it('returns authorized=false when no ISSUER permission', async () => {
+    const idx = mockIndexer({
+      listPermissions: vi.fn().mockResolvedValue({ permissions: [] }),
+    });
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/issuer-authorization?did=did:web:unknown.example.com&vtjscId=https://example.com/schemas/regulated-insurer/v1',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.authorized).toBe(false);
+    expect(body.reason).toMatch(/No active ISSUER permission/);
+  });
+});
+
+// --- Authorized with fees + session ---
+
+describe('Q2 /v1/trust/issuer-authorization \u2014 authorized', () => {
+  it('returns authorized=true with permission chain and fees when session provided', async () => {
+    const idx = mockIndexer();
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/issuer-authorization?did=did:web:ca-doi.gov.example.com&vtjscId=https://example.com/schemas/regulated-insurer/v1&sessionId=b2c3d4e5-f6a7-8901-bcde-f12345678901',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.authorized).toBe(true);
+    expect(body.did).toBe('did:web:ca-doi.gov.example.com');
+    expect(body.permission.id).toBe(142);
+    expect(body.permission.type).toBe('ISSUER');
+    expect(body.permissionChain).toHaveLength(3);
+    expect(body.permissionChain[0].type).toBe('ISSUER');
+    expect(body.permissionChain[1].type).toBe('ISSUER_GRANTOR');
+    expect(body.permissionChain[2].type).toBe('ECOSYSTEM');
+    expect(body.fees.required).toBe(true);
+    expect(body.session.id).toBe('b2c3d4e5-f6a7-8901-bcde-f12345678901');
+    expect(body.session.paid).toBe(true);
+    expect(res.headers['x-evaluated-at-block']).toBe('1500000');
+  });
+
+  it('returns HTTP 402 when fees required but no sessionId', async () => {
+    const idx = mockIndexer();
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/issuer-authorization?did=did:web:ca-doi.gov.example.com&vtjscId=https://example.com/schemas/regulated-insurer/v1',
+    });
+    expect(res.statusCode).toBe(402);
+    const body = res.json();
+    expect(body.authorized).toBe(false);
+    expect(body.reason).toMatch(/Payment required/);
+    expect(body.fees.required).toBe(true);
+    expect(body.fees.beneficiaries).toHaveLength(3);
+  });
+
+  it('returns authorized=true with no fees when discount is 1', async () => {
+    const idx = mockIndexer({
+      listPermissions: vi.fn().mockResolvedValue({
+        permissions: [
+          {
+            id: '142', schema_id: '7', type: 'ISSUER',
+            grantee: 'verana1abc', did: 'did:web:ca-doi.gov.example.com',
+            created: '2025-01-01T00:00:00Z', modified: '2025-01-01T00:00:00Z',
+            effective: '2025-01-01T00:00:00Z', expiration: '2027-01-01T00:00:00Z',
+            effective_until: '2027-01-01T00:00:00Z',
+            revoked: null, slashed: null, repaid: null,
+            deposit: '5000000uvna', country: 'US',
+            vp_state: 'VALIDATED', perm_state: 'ACTIVE',
+            validator_perm_id: '50',
+            issuance_fees: '500000uvna',
+            issuance_fee_discount: '1',
+            issued: 0, verified: 0,
+            ecosystem_slash_events: 0, ecosystem_slashed_amount: '0',
+            network_slash_events: 0, network_slashed_amount: '0',
+          },
+        ],
+      }),
+    });
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/issuer-authorization?did=did:web:ca-doi.gov.example.com&vtjscId=https://example.com/schemas/regulated-insurer/v1',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.authorized).toBe(true);
+    expect(body.fees.required).toBe(false);
+  });
+});
+
+// --- Session not found ---
+
+describe('Q2 /v1/trust/issuer-authorization \u2014 session errors', () => {
+  it('returns 400 when sessionId not found', async () => {
+    const idx = mockIndexer({
+      getPermissionSession: vi.fn().mockRejectedValue(
+        new IndexerError('Not found', 404, 'NOT_FOUND'),
+      ),
+    });
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/issuer-authorization?did=did:web:ca-doi.gov.example.com&vtjscId=https://example.com/schemas/regulated-insurer/v1&sessionId=nonexistent',
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toMatch(/PermissionSession not found/);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Q2 REST endpoint for on-demand issuer authorization checks. Evaluated using hot Indexer queries — no PostgreSQL reads needed.

Replaces #38 (which had merge conflicts due to incorrect branching).

### Endpoint

```
GET /v1/trust/issuer-authorization?did=...&vtjscId=...&sessionId=...&at=...
```

### Parameters
- **`did`** (required) — the DID to check
- **`vtjscId`** (required) — VTJSC URI (maps to CredentialSchema via Indexer)
- **`sessionId`** (optional) — PermissionSession UUID for fee payment verification
- **`at`** (optional) — block height for point-in-time evaluation

### Algorithm
1. Map `vtjscId` → `CredentialSchema` via `listCredentialSchemas`
2. Find ACTIVE `ISSUER` permission via `listPermissions(did, schema_id, type=ISSUER)`
3. Build on-chain permission chain: ISSUER → ISSUER_GRANTOR → ECOSYSTEM
4. Compute fees via `findBeneficiaries(issuer_perm_id)`
5. HTTP 402 if fees required but no `sessionId`
6. Verify `PermissionSession` if `sessionId` provided

### Response cases
- **`authorized: true`** — with permission, chain, fees, optional session
- **`authorized: false`** — no active ISSUER permission (200)
- **HTTP 402** — fees required, no sessionId
- **HTTP 404** — schema not found
- **HTTP 400** — invalid params or session not found

### New/changed files

| File | Description |
|------|-------------|
| `src/routes/q2-issuer-auth.ts` | Route handler with schema lookup, permission check, chain building, fee computation, session verification |
| `src/indexer/types.ts` | Added fee fields to `Permission` (`issuance_fees`, `verification_fees`, `issuance_fee_discount`, `verification_fee_discount`, `effective_until`); fixed `BeneficiaryResponse` to use `Permission[]`; added `json_schema` to `ListCredentialSchemasParams` |
| `src/index.ts` | Registers Q2 route with `IndexerClient` |
| `test/q2-issuer-auth.test.ts` | 9 tests: validation (3), schema 404 (1), not authorized (1), authorized+fees+session (1), 402 (1), discount (1), session errors (1) |

### Test results
- 94 tests pass (9 new + 85 existing)
- TypeScript compiles clean
- Branch created from `main` (no conflicts)

Closes #20