### PR TITLE
feat: add Q3 endpoint GET /v1/trust/verifier-authorization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { loadConfig } from './config/index.js';
 import { loadVprAllowlist } from './config/vpr-allowlist.js';
 import { registerQ1Route } from './routes/q1-resolve.js';
 import { createQ2Route } from './routes/q2-issuer-auth.js';
+import { createQ3Route } from './routes/q3-verifier-auth.js';
 import { IndexerClient } from './indexer/client.js';
 
 async function main(): Promise<void> {
@@ -28,6 +29,7 @@ async function main(): Promise<void> {
   // Q2+ endpoints need IndexerClient
   const indexer = new IndexerClient(allowlist.vprs[0]?.indexerUrl ?? 'http://localhost:3001');
   await createQ2Route(indexer)(server);
+  await createQ3Route(indexer)(server);
 
   await server.listen({ port: config.PORT, host: '0.0.0.0' });
   server.log.info(

--- a/src/routes/q3-verifier-auth.ts
+++ b/src/routes/q3-verifier-auth.ts
@@ -1,0 +1,264 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { IndexerClient } from '../indexer/client.js';
+import type { Permission } from '../indexer/types.js';
+import { IndexerError } from '../indexer/errors.js';
+
+interface Q3QueryString {
+  did?: string;
+  vtjscId?: string;
+  sessionId?: string;
+  at?: string;
+}
+
+export function createQ3Route(indexer: IndexerClient) {
+  return async function registerQ3Route(server: FastifyInstance): Promise<void> {
+    server.get<{ Querystring: Q3QueryString }>(
+      '/v1/trust/verifier-authorization',
+      async (request: FastifyRequest<{ Querystring: Q3QueryString }>, reply: FastifyReply) => {
+        const { did, vtjscId, sessionId, at } = request.query;
+
+        // --- Parameter validation ---
+        if (!did || typeof did !== 'string' || !did.startsWith('did:')) {
+          return reply.status(400).send({
+            error: 'Bad Request',
+            message: 'Missing or invalid "did" query parameter. Must be a valid DID.',
+          });
+        }
+
+        if (!vtjscId || typeof vtjscId !== 'string') {
+          return reply.status(400).send({
+            error: 'Bad Request',
+            message: 'Missing or invalid "vtjscId" query parameter.',
+          });
+        }
+
+        // Parse optional block height
+        const atBlock = parseAtParam(at);
+
+        // --- 1. Map vtjscId \u2192 CredentialSchema ---
+        let schemaId: string;
+        try {
+          const schemas = await indexer.listCredentialSchemas({ json_schema: vtjscId }, atBlock);
+          const match = schemas.credential_schemas.find((s) => s.json_schema === vtjscId);
+          if (!match) {
+            return reply.status(404).send({
+              error: 'Not Found',
+              message: `No CredentialSchema found for VTJSC: ${vtjscId}`,
+            });
+          }
+          schemaId = match.id;
+        } catch (err) {
+          if (err instanceof IndexerError && err.statusCode === 404) {
+            return reply.status(404).send({
+              error: 'Not Found',
+              message: `No CredentialSchema found for VTJSC: ${vtjscId}`,
+            });
+          }
+          throw err;
+        }
+
+        // --- 2. Find active VERIFIER permission ---
+        const permResp = await indexer.listPermissions(
+          { did, schema_id: schemaId, type: 'VERIFIER', only_valid: true },
+          atBlock,
+        );
+
+        const verifierPerm = permResp.permissions.find((p) => p.perm_state === 'ACTIVE');
+
+        const now = new Date().toISOString();
+        const blockHeight = atBlock ?? (await indexer.getBlockHeight()).height;
+
+        if (!verifierPerm) {
+          return reply.send({
+            did,
+            vtjscId,
+            authorized: false,
+            evaluatedAt: now,
+            evaluatedAtBlock: blockHeight,
+            reason: `No active VERIFIER permission found for DID on schema ${schemaId} (VTJSC: ${vtjscId})`,
+          });
+        }
+
+        // --- 3. Build permission chain (on-chain facts only) ---
+        const permissionChain = await buildOnChainPermissionChain(indexer, verifierPerm, atBlock);
+
+        // --- 4. Compute fees via findBeneficiaries ---
+        const feeResult = await computeVerificationFees(indexer, verifierPerm, atBlock);
+
+        // --- 5. Fee/session handling ---
+        if (feeResult.required && !sessionId) {
+          return reply.status(402).send({
+            authorized: false,
+            did,
+            vtjscId,
+            evaluatedAt: now,
+            evaluatedAtBlock: blockHeight,
+            reason:
+              'Payment required. Verification fees are enabled for this schema but no sessionId was provided. The verifier must create a PermissionSession (MOD-PERM-MSG-10) and re-query with the sessionId.',
+            fees: feeResult,
+          });
+        }
+
+        // --- 6. Session verification (if provided) ---
+        let session: Record<string, unknown> | undefined;
+        if (sessionId) {
+          try {
+            const sessResp = await indexer.getPermissionSession(sessionId, atBlock);
+            const sess = sessResp.permission_session;
+
+            // Verify session references the correct verifier permission
+            const matchesVerifier = sess.records.some(
+              (r) => r.verifier_perm_id === verifierPerm.id,
+            );
+
+            session = {
+              id: sess.id,
+              paid: matchesVerifier,
+              verifierPermId: Number(verifierPerm.id),
+              agentPermId: Number(sess.agent_perm_id),
+              walletAgentPermId: sess.records[0]?.wallet_agent_perm_id
+                ? Number(sess.records[0].wallet_agent_perm_id)
+                : null,
+              created: sess.created,
+            };
+          } catch (err) {
+            if (err instanceof IndexerError && err.statusCode === 404) {
+              return reply.status(400).send({
+                error: 'Bad Request',
+                message: `PermissionSession not found: ${sessionId}`,
+              });
+            }
+            throw err;
+          }
+        }
+
+        // --- 7. Build response ---
+        const response: Record<string, unknown> = {
+          did,
+          vtjscId,
+          authorized: true,
+          evaluatedAt: now,
+          evaluatedAtBlock: blockHeight,
+          permission: {
+            id: Number(verifierPerm.id),
+            type: verifierPerm.type,
+            schemaId: Number(verifierPerm.schema_id),
+            did: verifierPerm.did,
+            deposit: verifierPerm.deposit,
+            permState: verifierPerm.perm_state,
+            effectiveFrom: verifierPerm.effective,
+            effectiveUntil: verifierPerm.effective_until ?? verifierPerm.expiration,
+            verificationFeeDiscount: verifierPerm.verification_fee_discount ?? '0',
+          },
+          fees: feeResult,
+          permissionChain,
+        };
+
+        if (session) {
+          response.session = session;
+        }
+
+        reply.header('X-Evaluated-At-Block', String(blockHeight));
+        return reply.send(response);
+      },
+    );
+  };
+}
+
+async function buildOnChainPermissionChain(
+  indexer: IndexerClient,
+  verifierPerm: Permission,
+  atBlock?: number,
+): Promise<Array<Record<string, unknown>>> {
+  const chain: Array<Record<string, unknown>> = [];
+
+  // VERIFIER entry
+  chain.push({
+    permissionId: Number(verifierPerm.id),
+    type: verifierPerm.type,
+    did: verifierPerm.did,
+    deposit: verifierPerm.deposit,
+    permState: verifierPerm.perm_state,
+  });
+
+  // Walk to parent: VERIFIER_GRANTOR (if validator_perm_id set)
+  if (verifierPerm.validator_perm_id) {
+    try {
+      const grantorResp = await indexer.getPermission(verifierPerm.validator_perm_id, atBlock);
+      const grantor = grantorResp.permission;
+      chain.push({
+        permissionId: Number(grantor.id),
+        type: grantor.type,
+        did: grantor.did,
+        deposit: grantor.deposit,
+        permState: grantor.perm_state,
+      });
+
+      // Walk to ECOSYSTEM
+      if (grantor.validator_perm_id) {
+        const ecoResp = await indexer.getPermission(grantor.validator_perm_id, atBlock);
+        const eco = ecoResp.permission;
+        chain.push({
+          permissionId: Number(eco.id),
+          type: eco.type,
+          did: eco.did,
+          deposit: eco.deposit,
+          permState: eco.perm_state,
+        });
+      }
+    } catch {
+      // Chain may be incomplete \u2014 that's acceptable
+    }
+  }
+
+  return chain;
+}
+
+async function computeVerificationFees(
+  indexer: IndexerClient,
+  verifierPerm: Permission,
+  atBlock?: number,
+): Promise<Record<string, unknown>> {
+  try {
+    const beneResp = await indexer.findBeneficiaries('0', verifierPerm.id, atBlock);
+    const beneficiaries = beneResp.permissions.map((p) => ({
+      permissionId: Number(p.id),
+      type: p.type,
+      verificationFees: p.verification_fees ?? '0',
+    }));
+
+    const totalFees = beneficiaries.reduce((sum, b) => {
+      const feeStr = b.verificationFees.replace(/[^0-9]/g, '');
+      return sum + (Number(feeStr) || 0);
+    }, 0);
+
+    // Check discount
+    const discount = Number(verifierPerm.verification_fee_discount ?? '0');
+    const effectiveTotal = discount >= 1 ? 0 : totalFees;
+
+    if (effectiveTotal === 0) {
+      return {
+        required: false,
+        note: 'All verification fees are zero or fully discounted (verificationFeeDiscount=1). No PermissionSession required for fee payment.',
+      };
+    }
+
+    return {
+      required: true,
+      pricingAssetType: 'COIN',
+      pricingAsset: 'uvna',
+      totalBeneficiaryFees: `${effectiveTotal}uvna`,
+      beneficiaries,
+    };
+  } catch {
+    // If beneficiary lookup fails, assume no fees
+    return { required: false };
+  }
+}
+
+function parseAtParam(at?: string): number | undefined {
+  if (!at) return undefined;
+  const num = Number(at);
+  if (!Number.isNaN(num) && Number.isInteger(num) && num > 0) return num;
+  return undefined;
+}

--- a/test/q3-verifier-auth.test.ts
+++ b/test/q3-verifier-auth.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import { createQ3Route } from '../src/routes/q3-verifier-auth.js';
+import { IndexerError } from '../src/indexer/errors.js';
+
+function mockIndexer(overrides: Record<string, unknown> = {}) {
+  return {
+    listCredentialSchemas: vi.fn().mockResolvedValue({
+      credential_schemas: [
+        { id: '12', json_schema: 'https://credentials.hr-ecosystem.example.com/schemas/employment-cert/v1', tr_id: '3' },
+      ],
+    }),
+    listPermissions: vi.fn().mockResolvedValue({
+      permissions: [
+        {
+          id: '275',
+          schema_id: '12',
+          type: 'VERIFIER',
+          grantee: 'verana1vrf',
+          did: 'did:web:employer-portal.example.com',
+          created: '2025-04-01T00:00:00Z',
+          modified: '2025-04-01T00:00:00Z',
+          effective: '2025-04-01T00:00:00Z',
+          expiration: '2027-04-01T00:00:00Z',
+          effective_until: '2027-04-01T00:00:00Z',
+          revoked: null,
+          slashed: null,
+          repaid: null,
+          deposit: '2000000uvna',
+          country: 'EU',
+          vp_state: 'VALIDATED',
+          perm_state: 'ACTIVE',
+          validator_perm_id: '100',
+          verification_fees: '50uvna',
+          verification_fee_discount: '0',
+          issued: 0,
+          verified: 0,
+          ecosystem_slash_events: 0,
+          ecosystem_slashed_amount: '0',
+          network_slash_events: 0,
+          network_slashed_amount: '0',
+        },
+      ],
+    }),
+    getPermission: vi.fn().mockImplementation((id: string) => {
+      if (id === '100') {
+        return Promise.resolve({
+          permission: {
+            id: '100', type: 'VERIFIER_GRANTOR', did: 'did:web:eu-hr-association.example.com',
+            deposit: '15000000uvna', perm_state: 'ACTIVE', validator_perm_id: '12',
+            schema_id: '12', grantee: 'verana1gran',
+          },
+        });
+      }
+      if (id === '12') {
+        return Promise.resolve({
+          permission: {
+            id: '12', type: 'ECOSYSTEM', did: 'did:web:hr-ecosystem.example.com',
+            deposit: '60000000uvna', perm_state: 'ACTIVE', validator_perm_id: null,
+            schema_id: '12', grantee: 'verana1eco',
+          },
+        });
+      }
+      throw new IndexerError('Not found', 404, 'NOT_FOUND');
+    }),
+    findBeneficiaries: vi.fn().mockResolvedValue({
+      permissions: [
+        { id: '275', type: 'VERIFIER', verification_fees: '50uvna' },
+        { id: '100', type: 'VERIFIER_GRANTOR', verification_fees: '50uvna' },
+        { id: '12', type: 'ECOSYSTEM', verification_fees: '50uvna' },
+      ],
+    }),
+    getBlockHeight: vi.fn().mockResolvedValue({ height: 1500000 }),
+    getPermissionSession: vi.fn().mockResolvedValue({
+      permission_session: {
+        id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        authority: 'verana1vrf',
+        vs_operator: 'verana1op',
+        agent_perm_id: '88',
+        created: '2026-02-13T09:58:00Z',
+        modified: '2026-02-13T09:58:00Z',
+        records: [
+          { issuer_perm_id: '0', verifier_perm_id: '275', wallet_agent_perm_id: '88' },
+        ],
+      },
+    }),
+    ...overrides,
+  } as any;
+}
+
+async function buildApp(indexer: any) {
+  const app = Fastify();
+  await createQ3Route(indexer)(app);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// --- Parameter validation ---
+
+describe('Q3 /v1/trust/verifier-authorization \u2014 parameter validation', () => {
+  it('returns 400 when did is missing', async () => {
+    const app = await buildApp(mockIndexer());
+    const res = await app.inject({ method: 'GET', url: '/v1/trust/verifier-authorization' });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toMatch(/Missing or invalid "did"/);
+  });
+
+  it('returns 400 when did does not start with did:', async () => {
+    const app = await buildApp(mockIndexer());
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/verifier-authorization?did=notadid&vtjscId=https://example.com/schema',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when vtjscId is missing', async () => {
+    const app = await buildApp(mockIndexer());
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/verifier-authorization?did=did:web:test.example.com',
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toMatch(/Missing or invalid "vtjscId"/);
+  });
+});
+
+// --- Schema not found ---
+
+describe('Q3 /v1/trust/verifier-authorization \u2014 schema lookup', () => {
+  it('returns 404 when schema not found', async () => {
+    const idx = mockIndexer({
+      listCredentialSchemas: vi.fn().mockResolvedValue({ credential_schemas: [] }),
+    });
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/verifier-authorization?did=did:web:test.example.com&vtjscId=https://unknown.example.com/schema',
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().message).toMatch(/No CredentialSchema found/);
+  });
+});
+
+// --- Not authorized ---
+
+describe('Q3 /v1/trust/verifier-authorization \u2014 not authorized', () => {
+  it('returns authorized=false when no VERIFIER permission', async () => {
+    const idx = mockIndexer({
+      listPermissions: vi.fn().mockResolvedValue({ permissions: [] }),
+    });
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/verifier-authorization?did=did:web:unknown.example.com&vtjscId=https://credentials.hr-ecosystem.example.com/schemas/employment-cert/v1',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.authorized).toBe(false);
+    expect(body.reason).toMatch(/No active VERIFIER permission/);
+  });
+});
+
+// --- Authorized with fees + session ---
+
+describe('Q3 /v1/trust/verifier-authorization \u2014 authorized', () => {
+  it('returns authorized=true with permission chain and fees when session provided', async () => {
+    const idx = mockIndexer();
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/verifier-authorization?did=did:web:employer-portal.example.com&vtjscId=https://credentials.hr-ecosystem.example.com/schemas/employment-cert/v1&sessionId=a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.authorized).toBe(true);
+    expect(body.did).toBe('did:web:employer-portal.example.com');
+    expect(body.permission.id).toBe(275);
+    expect(body.permission.type).toBe('VERIFIER');
+    expect(body.permission.verificationFeeDiscount).toBe('0');
+    expect(body.permissionChain).toHaveLength(3);
+    expect(body.permissionChain[0].type).toBe('VERIFIER');
+    expect(body.permissionChain[1].type).toBe('VERIFIER_GRANTOR');
+    expect(body.permissionChain[2].type).toBe('ECOSYSTEM');
+    expect(body.fees.required).toBe(true);
+    expect(body.fees.beneficiaries[0].verificationFees).toBe('50uvna');
+    expect(body.session.id).toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
+    expect(body.session.paid).toBe(true);
+    expect(body.session.verifierPermId).toBe(275);
+    expect(res.headers['x-evaluated-at-block']).toBe('1500000');
+  });
+
+  it('returns HTTP 402 when fees required but no sessionId', async () => {
+    const idx = mockIndexer();
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/verifier-authorization?did=did:web:employer-portal.example.com&vtjscId=https://credentials.hr-ecosystem.example.com/schemas/employment-cert/v1',
+    });
+    expect(res.statusCode).toBe(402);
+    const body = res.json();
+    expect(body.authorized).toBe(false);
+    expect(body.reason).toMatch(/Payment required/);
+    expect(body.reason).toMatch(/Verification fees/);
+    expect(body.fees.required).toBe(true);
+    expect(body.fees.beneficiaries).toHaveLength(3);
+  });
+
+  it('returns authorized=true with no fees when discount is 1', async () => {
+    const idx = mockIndexer({
+      listPermissions: vi.fn().mockResolvedValue({
+        permissions: [
+          {
+            id: '275', schema_id: '12', type: 'VERIFIER',
+            grantee: 'verana1vrf', did: 'did:web:employer-portal.example.com',
+            created: '2025-04-01T00:00:00Z', modified: '2025-04-01T00:00:00Z',
+            effective: '2025-04-01T00:00:00Z', expiration: '2027-04-01T00:00:00Z',
+            effective_until: '2027-04-01T00:00:00Z',
+            revoked: null, slashed: null, repaid: null,
+            deposit: '2000000uvna', country: 'EU',
+            vp_state: 'VALIDATED', perm_state: 'ACTIVE',
+            validator_perm_id: '100',
+            verification_fees: '50uvna',
+            verification_fee_discount: '1',
+            issued: 0, verified: 0,
+            ecosystem_slash_events: 0, ecosystem_slashed_amount: '0',
+            network_slash_events: 0, network_slashed_amount: '0',
+          },
+        ],
+      }),
+    });
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/verifier-authorization?did=did:web:employer-portal.example.com&vtjscId=https://credentials.hr-ecosystem.example.com/schemas/employment-cert/v1',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.authorized).toBe(true);
+    expect(body.fees.required).toBe(false);
+    expect(body.permission.verificationFeeDiscount).toBe('1');
+  });
+});
+
+// --- Session not found ---
+
+describe('Q3 /v1/trust/verifier-authorization \u2014 session errors', () => {
+  it('returns 400 when sessionId not found', async () => {
+    const idx = mockIndexer({
+      getPermissionSession: vi.fn().mockRejectedValue(
+        new IndexerError('Not found', 404, 'NOT_FOUND'),
+      ),
+    });
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/verifier-authorization?did=did:web:employer-portal.example.com&vtjscId=https://credentials.hr-ecosystem.example.com/schemas/employment-cert/v1&sessionId=nonexistent',
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toMatch(/PermissionSession not found/);
+  });
+});
+
+// --- findBeneficiaries uses verifier_perm_id ---
+
+describe('Q3 /v1/trust/verifier-authorization \u2014 fee computation', () => {
+  it('calls findBeneficiaries with verifier_perm_id (second arg)', async () => {
+    const idx = mockIndexer();
+    const app = await buildApp(idx);
+    await app.inject({
+      method: 'GET',
+      url: '/v1/trust/verifier-authorization?did=did:web:employer-portal.example.com&vtjscId=https://credentials.hr-ecosystem.example.com/schemas/employment-cert/v1&sessionId=a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    });
+    // findBeneficiaries should be called with ('0', verifierPermId, atBlock)
+    expect(idx.findBeneficiaries).toHaveBeenCalledWith('0', '275', undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Q3 REST endpoint for on-demand verifier authorization checks. Mirrors Q2 (issuer authorization) but uses `VERIFIER` permissions and `verification_fees`.

### Endpoint

```
GET /v1/trust/verifier-authorization?did=...&vtjscId=...&sessionId=...&at=...
```

### Parameters
- **`did`** (required) — the DID to check
- **`vtjscId`** (required) — VTJSC URI (maps to CredentialSchema via Indexer)
- **`sessionId`** (optional) — PermissionSession UUID for fee payment verification
- **`at`** (optional) — block height for point-in-time evaluation

### Algorithm
1. Map `vtjscId` → `CredentialSchema` via `listCredentialSchemas`
2. Find ACTIVE `VERIFIER` permission via `listPermissions(did, schema_id, type=VERIFIER)`
3. Build on-chain permission chain: VERIFIER → VERIFIER_GRANTOR → ECOSYSTEM
4. Compute verification fees via `findBeneficiaries('0', verifier_perm_id)`
5. HTTP 402 if fees required but no `sessionId`
6. Verify `PermissionSession` matching `verifier_perm_id` if `sessionId` provided

### Key differences from Q2
| Aspect | Q2 (Issuer) | Q3 (Verifier) |
|--------|-------------|---------------|
| Permission type | `ISSUER` | `VERIFIER` |
| Chain walk | ISSUER → ISSUER_GRANTOR → ECOSYSTEM | VERIFIER → VERIFIER_GRANTOR → ECOSYSTEM |
| Fee field | `issuance_fees` / `issuance_fee_discount` | `verification_fees` / `verification_fee_discount` |
| findBeneficiaries | `(issuer_perm_id, '0')` | `('0', verifier_perm_id)` |
| Session match | `issuer_perm_id` | `verifier_perm_id` |
| Response field | `issuanceFeeDiscount` | `verificationFeeDiscount` |

### Response cases
- **`authorized: true`** — with permission, chain, fees, optional session
- **`authorized: false`** — no active VERIFIER permission (200)
- **HTTP 402** — fees required, no sessionId
- **HTTP 404** — schema not found
- **HTTP 400** — invalid params or session not found

### New/changed files

| File | Description |
|------|-------------|
| `src/routes/q3-verifier-auth.ts` | Route handler with schema lookup, VERIFIER permission check, chain building, verification fee computation, session verification |
| `src/index.ts` | Registers Q3 route with IndexerClient |
| `test/q3-verifier-auth.test.ts` | 10 tests: validation (3), schema 404 (1), not authorized (1), authorized+fees+session (1), 402 (1), discount (1), session errors (1), findBeneficiaries arg verification (1) |

### Test results
- 104 tests pass (10 new + 94 existing)
- TypeScript compiles clean
- Branch created from `main` (no conflicts)

Closes #21