### PR TITLE
feat: add Q4 endpoint GET /v1/trust/ecosystem-participant

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { loadVprAllowlist } from './config/vpr-allowlist.js';
 import { registerQ1Route } from './routes/q1-resolve.js';
 import { createQ2Route } from './routes/q2-issuer-auth.js';
 import { createQ3Route } from './routes/q3-verifier-auth.js';
+import { createQ4Route } from './routes/q4-ecosystem-participant.js';
 import { IndexerClient } from './indexer/client.js';
 
 async function main(): Promise<void> {
@@ -30,6 +31,7 @@ async function main(): Promise<void> {
   const indexer = new IndexerClient(allowlist.vprs[0]?.indexerUrl ?? 'http://localhost:3001');
   await createQ2Route(indexer)(server);
   await createQ3Route(indexer)(server);
+  await createQ4Route(indexer)(server);
 
   await server.listen({ port: config.PORT, host: '0.0.0.0' });
   server.log.info(

--- a/src/indexer/client.ts
+++ b/src/indexer/client.ts
@@ -14,6 +14,8 @@ import type {
   PriceResponse,
   ListPermissionsParams,
   ListCredentialSchemasParams,
+  ListTrustRegistriesParams,
+  TrustRegistryListResponse,
   GetExchangeRateParams,
   GetPriceParams,
 } from './types.js';
@@ -54,6 +56,13 @@ export class IndexerClient {
     atBlock?: number,
   ): Promise<TrustRegistryResponse> {
     return this.get<TrustRegistryResponse>(`/verana/tr/v1/get/${id}`, {}, atBlock);
+  }
+
+  async listTrustRegistries(
+    params: ListTrustRegistriesParams = {},
+    atBlock?: number,
+  ): Promise<TrustRegistryListResponse> {
+    return this.get<TrustRegistryListResponse>('/verana/tr/v1/list', { ...params }, atBlock);
   }
 
   // --- Credential Schema ---

--- a/src/indexer/types.ts
+++ b/src/indexer/types.ts
@@ -253,6 +253,16 @@ export interface GetExchangeRateParams {
   expire_ts?: string;
 }
 
+export interface ListTrustRegistriesParams {
+  active_gf_only?: boolean;
+  preferred_language?: string;
+  authority?: string;
+  controller?: string;
+  only_active?: boolean;
+  participant?: string;
+  response_max_size?: number;
+}
+
 export interface GetPriceParams {
   base_asset_type: string;
   base_asset: string;

--- a/src/routes/q4-ecosystem-participant.ts
+++ b/src/routes/q4-ecosystem-participant.ts
@@ -1,0 +1,113 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { IndexerClient } from '../indexer/client.js';
+import type { Permission } from '../indexer/types.js';
+
+interface Q4QueryString {
+  did?: string;
+  ecosystemDid?: string;
+  at?: string;
+}
+
+export function createQ4Route(indexer: IndexerClient) {
+  return async function registerQ4Route(server: FastifyInstance): Promise<void> {
+    server.get<{ Querystring: Q4QueryString }>(
+      '/v1/trust/ecosystem-participant',
+      async (request: FastifyRequest<{ Querystring: Q4QueryString }>, reply: FastifyReply) => {
+        const { did, ecosystemDid, at } = request.query;
+
+        // --- Parameter validation ---
+        if (!did || typeof did !== 'string' || !did.startsWith('did:')) {
+          return reply.status(400).send({
+            error: 'Bad Request',
+            message: 'Missing or invalid "did" query parameter. Must be a valid DID.',
+          });
+        }
+
+        if (!ecosystemDid || typeof ecosystemDid !== 'string' || !ecosystemDid.startsWith('did:')) {
+          return reply.status(400).send({
+            error: 'Bad Request',
+            message: 'Missing or invalid "ecosystemDid" query parameter. Must be a valid DID.',
+          });
+        }
+
+        // Parse optional block height
+        const atBlock = parseAtParam(at);
+
+        // --- 1. Resolve ecosystemDid \u2192 TrustRegistry ---
+        const trListResp = await indexer.listTrustRegistries({}, atBlock);
+        const trustRegistry = trListResp.trust_registries.find((tr) => tr.did === ecosystemDid);
+
+        if (!trustRegistry) {
+          return reply.status(404).send({
+            error: 'Not Found',
+            message: `No Trust Registry found for ecosystem DID: ${ecosystemDid}`,
+          });
+        }
+
+        const trId = trustRegistry.id;
+        const ecosystemAka = trustRegistry.aka ?? undefined;
+
+        // --- 2. Get all CredentialSchemas for this ecosystem ---
+        const schemasResp = await indexer.listCredentialSchemas({ tr_id: trId }, atBlock);
+        const schemas = schemasResp.credential_schemas;
+
+        // --- 3. For each schema, find ACTIVE permissions for did ---
+        const allPermissions: Array<Record<string, unknown>> = [];
+
+        for (const schema of schemas) {
+          const permResp = await indexer.listPermissions(
+            { did, schema_id: schema.id, only_valid: true },
+            atBlock,
+          );
+
+          for (const perm of permResp.permissions) {
+            if (perm.perm_state === 'ACTIVE') {
+              allPermissions.push(formatPermission(perm, schema.json_schema));
+            }
+          }
+        }
+
+        // --- 4. Build response ---
+        const now = new Date().toISOString();
+        const blockHeight = atBlock ?? (await indexer.getBlockHeight()).height;
+
+        const response: Record<string, unknown> = {
+          did,
+          ecosystemDid,
+          isParticipant: allPermissions.length > 0,
+          evaluatedAt: now,
+          evaluatedAtBlock: blockHeight,
+          permissions: allPermissions,
+        };
+
+        if (ecosystemAka) {
+          response.ecosystemAka = ecosystemAka;
+        }
+
+        reply.header('X-Evaluated-At-Block', String(blockHeight));
+        return reply.send(response);
+      },
+    );
+  };
+}
+
+function formatPermission(perm: Permission, vtjscId: string): Record<string, unknown> {
+  return {
+    permissionId: Number(perm.id),
+    did: perm.did,
+    type: perm.type,
+    schemaId: Number(perm.schema_id),
+    vtjscId,
+    deposit: perm.deposit,
+    permState: perm.perm_state,
+    effectiveFrom: perm.effective,
+    effectiveUntil: perm.effective_until ?? perm.expiration,
+  };
+}
+
+function parseAtParam(at?: string): number | undefined {
+  if (!at) return undefined;
+  const num = Number(at);
+  if (!Number.isNaN(num) && Number.isInteger(num) && num > 0) return num;
+  return undefined;
+}

--- a/test/q4-ecosystem-participant.test.ts
+++ b/test/q4-ecosystem-participant.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import { createQ4Route } from '../src/routes/q4-ecosystem-participant.js';
+
+function mockIndexer(overrides: Record<string, unknown> = {}) {
+  return {
+    listTrustRegistries: vi.fn().mockResolvedValue({
+      trust_registries: [
+        {
+          id: '3',
+          did: 'did:web:insurance-trust.example.com',
+          controller: 'verana1eco',
+          created: '2024-01-01T00:00:00Z',
+          modified: '2024-06-01T00:00:00Z',
+          archived: null,
+          deposit: '60000000uvna',
+          aka: 'Global Insurance Trust Network',
+          language: 'en',
+          active_version: 1,
+          participants: 5,
+          active_schemas: 2,
+          archived_schemas: 0,
+          weight: '100',
+          issued: 0,
+          verified: 0,
+          ecosystem_slash_events: 0,
+          ecosystem_slashed_amount: '0',
+          ecosystem_slashed_amount_repaid: '0',
+          network_slash_events: 0,
+          network_slashed_amount: '0',
+          network_slashed_amount_repaid: '0',
+          versions: [],
+        },
+      ],
+    }),
+    listCredentialSchemas: vi.fn().mockResolvedValue({
+      credential_schemas: [
+        {
+          id: '7',
+          tr_id: '3',
+          title: 'ECS Service',
+          description: 'ECS Service credential schema',
+          json_schema: 'https://credentials.insurance-trust.example.com/schemas/ecs-service/v1',
+          created: '2024-01-01T00:00:00Z',
+          modified: '2024-01-01T00:00:00Z',
+          archived: null,
+        },
+        {
+          id: '8',
+          tr_id: '3',
+          title: 'Regulated Insurer',
+          description: 'Regulated Insurer credential schema',
+          json_schema: 'https://credentials.insurance-trust.example.com/schemas/regulated-insurer/v1',
+          created: '2024-01-01T00:00:00Z',
+          modified: '2024-01-01T00:00:00Z',
+          archived: null,
+        },
+      ],
+    }),
+    listPermissions: vi.fn().mockImplementation((params: { schema_id?: string }) => {
+      if (params.schema_id === '7') {
+        return Promise.resolve({
+          permissions: [
+            {
+              id: '142',
+              schema_id: '7',
+              type: 'ISSUER',
+              grantee: 'verana1abc',
+              did: 'did:web:ca-doi.gov.example.com',
+              effective: '2025-01-01T00:00:00Z',
+              expiration: '2027-01-01T00:00:00Z',
+              effective_until: '2027-01-01T00:00:00Z',
+              deposit: '5000000uvna',
+              perm_state: 'ACTIVE',
+              validator_perm_id: '50',
+            },
+            {
+              id: '50',
+              schema_id: '7',
+              type: 'ISSUER_GRANTOR',
+              grantee: 'verana1abc',
+              did: 'did:web:ca-doi.gov.example.com',
+              effective: '2024-06-01T00:00:00Z',
+              expiration: '2028-06-01T00:00:00Z',
+              effective_until: '2028-06-01T00:00:00Z',
+              deposit: '20000000uvna',
+              perm_state: 'ACTIVE',
+              validator_perm_id: '3',
+            },
+          ],
+        });
+      }
+      if (params.schema_id === '8') {
+        return Promise.resolve({
+          permissions: [
+            {
+              id: '143',
+              schema_id: '8',
+              type: 'ISSUER',
+              grantee: 'verana1abc',
+              did: 'did:web:ca-doi.gov.example.com',
+              effective: '2025-01-01T00:00:00Z',
+              expiration: '2027-01-01T00:00:00Z',
+              effective_until: '2027-01-01T00:00:00Z',
+              deposit: '5000000uvna',
+              perm_state: 'ACTIVE',
+              validator_perm_id: '50',
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ permissions: [] });
+    }),
+    getBlockHeight: vi.fn().mockResolvedValue({ height: 1500000 }),
+    ...overrides,
+  } as any;
+}
+
+async function buildApp(indexer: any) {
+  const app = Fastify();
+  await createQ4Route(indexer)(app);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// --- Parameter validation ---
+
+describe('Q4 /v1/trust/ecosystem-participant \u2014 parameter validation', () => {
+  it('returns 400 when did is missing', async () => {
+    const app = await buildApp(mockIndexer());
+    const res = await app.inject({ method: 'GET', url: '/v1/trust/ecosystem-participant' });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toMatch(/Missing or invalid "did"/);
+  });
+
+  it('returns 400 when did does not start with did:', async () => {
+    const app = await buildApp(mockIndexer());
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/ecosystem-participant?did=notadid&ecosystemDid=did:web:eco.example.com',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when ecosystemDid is missing', async () => {
+    const app = await buildApp(mockIndexer());
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/ecosystem-participant?did=did:web:test.example.com',
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toMatch(/Missing or invalid "ecosystemDid"/);
+  });
+
+  it('returns 400 when ecosystemDid does not start with did:', async () => {
+    const app = await buildApp(mockIndexer());
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/ecosystem-participant?did=did:web:test.example.com&ecosystemDid=notadid',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// --- Ecosystem not found ---
+
+describe('Q4 /v1/trust/ecosystem-participant \u2014 ecosystem lookup', () => {
+  it('returns 404 when ecosystem DID not found', async () => {
+    const idx = mockIndexer({
+      listTrustRegistries: vi.fn().mockResolvedValue({ trust_registries: [] }),
+    });
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/ecosystem-participant?did=did:web:test.example.com&ecosystemDid=did:web:unknown-eco.example.com',
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().message).toMatch(/No Trust Registry found/);
+  });
+});
+
+// --- Participant with multiple roles ---
+
+describe('Q4 /v1/trust/ecosystem-participant \u2014 participant', () => {
+  it('returns isParticipant=true with all active permissions across schemas', async () => {
+    const idx = mockIndexer();
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/ecosystem-participant?did=did:web:ca-doi.gov.example.com&ecosystemDid=did:web:insurance-trust.example.com',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.did).toBe('did:web:ca-doi.gov.example.com');
+    expect(body.ecosystemDid).toBe('did:web:insurance-trust.example.com');
+    expect(body.ecosystemAka).toBe('Global Insurance Trust Network');
+    expect(body.isParticipant).toBe(true);
+    expect(body.permissions).toHaveLength(3);
+    expect(body.permissions[0].permissionId).toBe(142);
+    expect(body.permissions[0].type).toBe('ISSUER');
+    expect(body.permissions[0].vtjscId).toBe('https://credentials.insurance-trust.example.com/schemas/ecs-service/v1');
+    expect(body.permissions[1].permissionId).toBe(50);
+    expect(body.permissions[1].type).toBe('ISSUER_GRANTOR');
+    expect(body.permissions[2].permissionId).toBe(143);
+    expect(body.permissions[2].type).toBe('ISSUER');
+    expect(body.permissions[2].schemaId).toBe(8);
+    expect(res.headers['x-evaluated-at-block']).toBe('1500000');
+  });
+
+  it('calls listPermissions once per schema with did filter', async () => {
+    const idx = mockIndexer();
+    const app = await buildApp(idx);
+    await app.inject({
+      method: 'GET',
+      url: '/v1/trust/ecosystem-participant?did=did:web:ca-doi.gov.example.com&ecosystemDid=did:web:insurance-trust.example.com',
+    });
+    expect(idx.listPermissions).toHaveBeenCalledTimes(2);
+    expect(idx.listPermissions).toHaveBeenCalledWith(
+      { did: 'did:web:ca-doi.gov.example.com', schema_id: '7', only_valid: true },
+      undefined,
+    );
+    expect(idx.listPermissions).toHaveBeenCalledWith(
+      { did: 'did:web:ca-doi.gov.example.com', schema_id: '8', only_valid: true },
+      undefined,
+    );
+  });
+});
+
+// --- Not a participant ---
+
+describe('Q4 /v1/trust/ecosystem-participant \u2014 not a participant', () => {
+  it('returns isParticipant=false when DID has no permissions', async () => {
+    const idx = mockIndexer({
+      listPermissions: vi.fn().mockResolvedValue({ permissions: [] }),
+    });
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/ecosystem-participant?did=did:web:random-service.example.com&ecosystemDid=did:web:insurance-trust.example.com',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.isParticipant).toBe(false);
+    expect(body.permissions).toHaveLength(0);
+    expect(body.ecosystemAka).toBe('Global Insurance Trust Network');
+  });
+});
+
+// --- No aka ---
+
+describe('Q4 /v1/trust/ecosystem-participant \u2014 no aka', () => {
+  it('omits ecosystemAka when trust registry has no aka', async () => {
+    const idx = mockIndexer({
+      listTrustRegistries: vi.fn().mockResolvedValue({
+        trust_registries: [
+          {
+            id: '3',
+            did: 'did:web:insurance-trust.example.com',
+            aka: null,
+            controller: 'verana1eco',
+            created: '2024-01-01T00:00:00Z',
+            archived: null,
+            deposit: '60000000uvna',
+            versions: [],
+          },
+        ],
+      }),
+      listPermissions: vi.fn().mockResolvedValue({ permissions: [] }),
+    });
+    const app = await buildApp(idx);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/v1/trust/ecosystem-participant?did=did:web:test.example.com&ecosystemDid=did:web:insurance-trust.example.com',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ecosystemAka).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Q4 REST endpoint — a pure hot Indexer query that checks whether a DID holds any active permissions within an ecosystem's trust registry.

### Endpoint

```
GET /v1/trust/ecosystem-participant?did=...&ecosystemDid=...&at=...
```

### Parameters
- **`did`** (required) — the DID to check
- **`ecosystemDid`** (required) — the ecosystem trust registry DID
- **`at`** (optional) — block height for point-in-time evaluation

### Algorithm
1. Resolve `ecosystemDid` → TrustRegistry via `listTrustRegistries` (client-side DID match)
2. `listCredentialSchemas(tr_id)` → get all schemas for the ecosystem
3. For each schema: `listPermissions(did, schema_id, only_valid=true)` → collect all ACTIVE permissions
4. Return aggregated result with on-chain facts only

### Response fields
- `isParticipant` — `true` if DID holds ≥1 active permission
- `ecosystemAka` — human-readable name (included when available)
- `permissions[]` — each entry: `permissionId`, `did`, `type`, `schemaId`, `vtjscId`, `deposit`, `permState`, `effectiveFrom`, `effectiveUntil`

### Key differences from Q2/Q3
| Aspect | Q2/Q3 | Q4 |
|--------|-------|-----|
| Purpose | Authorization check for specific schema | Ecosystem participation check |
| Fees/Sessions | Yes | No |
| Permission chain | Yes | No |
| Schema input | `vtjscId` (single) | All schemas in ecosystem |
| Lookup | By DID + schema | By DID across all ecosystem schemas |

### New/changed files

| File | Description |
|------|-------------|
| `src/routes/q4-ecosystem-participant.ts` | Route handler — ecosystem DID lookup, schema enumeration, permission aggregation |
| `src/indexer/client.ts` | Add `listTrustRegistries()` method |
| `src/indexer/types.ts` | Add `ListTrustRegistriesParams` interface |
| `src/index.ts` | Register Q4 route |
| `test/q4-ecosystem-participant.test.ts` | 9 tests: validation (4), ecosystem 404 (1), participant with multi-role (1), listPermissions call verification (1), not participant (1), no aka (1) |

### Test results
- 113 tests pass (9 new + 104 existing)
- TypeScript compiles clean
- Branched from `main`, no conflicts

Closes #22