### PR TITLE
fix: use npm install instead of npm ci (no package-lock.json in repo)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run tests
         run: npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ FROM node:22-alpine AS deps
 WORKDIR /app
 
 # Copy package files
-COPY package.json package-lock.json ./
+COPY package.json ./
 
 # Install all dependencies (including devDependencies for build)
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci
+    npm install
 
 # ============================================
 # Stage 2: Build the application
@@ -42,9 +42,9 @@ RUN addgroup -S -g 1001 nodejs \
     && adduser -S -u 1001 -G nodejs resolver
 
 # Copy package files and install production-only dependencies
-COPY --from=builder /app/package.json /app/package-lock.json ./
+COPY --from=builder /app/package.json ./
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci --omit=dev
+    npm install --omit=dev
 
 # Copy built application
 COPY --from=builder --chown=resolver:nodejs /app/dist ./dist


### PR DESCRIPTION
## Problem

The `dev-release.yml` workflow and `Dockerfile` both use `npm ci`, which requires `package-lock.json` to exist in the repo. The lockfile was never committed, causing CI to fail on the "Install dependencies" step.

## Fix

- **`Dockerfile`**: Changed `npm ci` → `npm install` in both deps and runner stages; removed `package-lock.json` from COPY commands
- **`dev-release.yml`**: Changed `npm ci` → `npm install`

## Follow-up

Commit `package-lock.json` to the repo and switch back to `npm ci` for reproducible builds.