### PR TITLE
fix: align dev-release.yml with verana-frontend pattern

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Run tests
-        run: npm test
-
       - name: Run semantic-release
         id: semantic
         uses: codfish/semantic-release-action@v3


### PR DESCRIPTION
## Problem

`dev-release.yml` had an extra `Run tests` step that doesn't exist in the verana-frontend reference workflow, and the `release` branch was missing (required by semantic-release as the non-prerelease branch).

## Changes

- Removed `Run tests` step from `dev-release.yml` to match verana-frontend exactly
- `release` branch was already created separately

## Verification

After merge, the dev-release workflow should match verana-frontend's pattern:
1. Checkout → Setup node → Install deps → semantic-release → Docker build+push