### PR TITLE
fix: resolve merge conflict markers in CI/CD workflow files

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -24,11 +24,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-<<<<<<< HEAD
         run: npm install
-=======
-        run: npm ci
->>>>>>> 9d5803a (ops: add GitHub Actions workflows (lint-pr, dev-release, stable-release))
 
       - name: Run tests
         run: npm test
@@ -100,7 +96,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-<<<<<<< HEAD
       - name: Set up Helm
         if: steps.semantic.outputs.new-release-published == 'true'
         uses: azure/setup-helm@v3
@@ -124,8 +119,6 @@ jobs:
             helm push ./charts/$CHART_NAME-$tag.tgz oci://docker.io/"${{ secrets.DOCKER_HUB_LOGIN }}"
           done
 
-=======
->>>>>>> 9d5803a (ops: add GitHub Actions workflows (lint-pr, dev-release, stable-release))
       - name: Publish Summary
         if: steps.semantic.outputs.new-release-published == 'true'
         run: |
@@ -135,11 +128,8 @@ jobs:
           echo "- verana-resolver:v${{ steps.semantic.outputs.release-major }}-dev" >> $GITHUB_STEP_SUMMARY
           echo "- verana-resolver:v${{ steps.semantic.outputs.release-major }}.${{ steps.semantic.outputs.release-minor }}-dev" >> $GITHUB_STEP_SUMMARY
           echo "- verana-resolver:v${{ steps.semantic.outputs.release-version }}" >> $GITHUB_STEP_SUMMARY
-<<<<<<< HEAD
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Helm Charts" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- verana-resolver-chart:v${{ steps.semantic.outputs.release-major }}.${{ steps.semantic.outputs.release-minor }}-dev" >> $GITHUB_STEP_SUMMARY
           echo "- verana-resolver-chart:v${{ steps.semantic.outputs.release-version }}" >> $GITHUB_STEP_SUMMARY
-=======
->>>>>>> 9d5803a (ops: add GitHub Actions workflows (lint-pr, dev-release, stable-release))

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -34,12 +34,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-<<<<<<< HEAD
       - name: Setup Helm
         uses: azure/setup-helm@v3
 
-=======
->>>>>>> 9d5803a (ops: add GitHub Actions workflows (lint-pr, dev-release, stable-release))
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -61,7 +58,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-<<<<<<< HEAD
       - name: Log in to Docker Hub Helm Registry
         run: |
           echo "${{ secrets.DOCKER_HUB_PWD }}" | helm registry login -u "${{ secrets.DOCKER_HUB_LOGIN }}" --password-stdin docker.io
@@ -73,18 +69,13 @@ jobs:
           helm package ./charts --version ${{ needs.release-please.outputs.tag_name }} -d ./charts
           helm push ./charts/$CHART_NAME-${{ needs.release-please.outputs.tag_name }}.tgz oci://docker.io/"${{ secrets.DOCKER_HUB_LOGIN }}"
 
-=======
->>>>>>> 9d5803a (ops: add GitHub Actions workflows (lint-pr, dev-release, stable-release))
       - name: Publish Summary
         run: |
           echo "Docker Images" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- verana-resolver:latest" >> $GITHUB_STEP_SUMMARY
           echo "- verana-resolver:${{ needs.release-please.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
-<<<<<<< HEAD
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Helm Charts" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- verana-resolver-chart:${{ needs.release-please.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
-=======
->>>>>>> 9d5803a (ops: add GitHub Actions workflows (lint-pr, dev-release, stable-release))


### PR DESCRIPTION
## Problem

Commit `b0cfdad` accidentally pushed unresolved merge conflict markers (`<<<<<<< HEAD`, `=======`, `>>>>>>>`) into both `dev-release.yml` and `stable-release.yml` on main.

## Fix

Resolves the conflicts by keeping:
- `npm install` (not `npm ci`, since `package-lock.json` is not yet committed)
- All Helm chart steps (setup, login, package, push)
- Helm chart info in the summary step