### PR TITLE
feat: add health/readiness endpoints and Prometheus metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@credo-ts/anoncreds": "^0.6.2",
     "@credo-ts/core": "^0.6.2",
     "@credo-ts/node": "^0.6.2",
     "@credo-ts/webvh": "^0.6.2",
-    "@credo-ts/anoncreds": "^0.6.2",
     "@fastify/cors": "^11.0.0",
     "canonicalize": "^2.0.0",
     "fastify": "^5.2.1",
@@ -31,6 +31,7 @@
     "jose": "^6.1.3",
     "pg": "^8.13.1",
     "pino": "^10.3.1",
+    "prom-client": "^15.1.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -1,0 +1,63 @@
+import { Registry, Gauge, Counter, Histogram, collectDefaultMetrics } from 'prom-client';
+
+export const registry = new Registry();
+
+// Collect Node.js default metrics (GC, event loop, memory, etc.)
+collectDefaultMetrics({ register: registry });
+
+// --- Gauges ---
+
+export const lastProcessedBlockGauge = new Gauge({
+  name: 'resolver_last_processed_block',
+  help: 'Last block height processed by the resolver',
+  registers: [registry],
+});
+
+export const blockLagGauge = new Gauge({
+  name: 'resolver_block_lag',
+  help: 'Difference between indexer block height and resolver last processed block',
+  registers: [registry],
+});
+
+export const reattemptableCountGauge = new Gauge({
+  name: 'resolver_reattemptable_count',
+  help: 'Current number of resources in the reattemptable table',
+  registers: [registry],
+});
+
+// --- Counters ---
+
+export const trustEvaluationsTotal = new Counter({
+  name: 'resolver_trust_evaluations_total',
+  help: 'Total number of trust evaluations performed',
+  registers: [registry],
+});
+
+export const redisHitsTotal = new Counter({
+  name: 'resolver_redis_hits_total',
+  help: 'Total number of Redis cache hits',
+  registers: [registry],
+});
+
+export const redisMissesTotal = new Counter({
+  name: 'resolver_redis_misses_total',
+  help: 'Total number of Redis cache misses',
+  registers: [registry],
+});
+
+export const indexerCallsTotal = new Counter({
+  name: 'resolver_indexer_calls_total',
+  help: 'Total number of calls to the Indexer API',
+  labelNames: ['endpoint'] as const,
+  registers: [registry],
+});
+
+// --- Histograms ---
+
+export const queryDurationSeconds = new Histogram({
+  name: 'resolver_query_duration_seconds',
+  help: 'Duration of HTTP query requests in seconds',
+  labelNames: ['endpoint', 'status_code'] as const,
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [registry],
+});

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,0 +1,112 @@
+import type { FastifyInstance } from 'fastify';
+import { getPool } from '../db/index.js';
+import { isRedisReady } from '../cache/redis-client.js';
+import { getLastProcessedBlock } from '../polling/resolver-state.js';
+import { getConfig } from '../config/index.js';
+
+interface HealthResponse {
+  status: 'ok' | 'syncing' | 'degraded';
+  lastProcessedBlock: number;
+  indexerBlockHeight: number | null;
+  blockLag: number | null;
+  instanceRole: string;
+  postgresConnected: boolean;
+  redisConnected: boolean;
+}
+
+async function checkPostgres(): Promise<boolean> {
+  try {
+    const pool = getPool();
+    await pool.query('SELECT 1');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Shared state: set by the polling loop so health can report indexer height
+// without making a live call on every health check
+let _indexerBlockHeight: number | null = null;
+
+export function setIndexerBlockHeight(height: number): void {
+  _indexerBlockHeight = height;
+}
+
+export function getIndexerBlockHeight(): number | null {
+  return _indexerBlockHeight;
+}
+
+function computeStatus(
+  lastProcessedBlock: number,
+  pgConnected: boolean,
+  redisConnected: boolean,
+): 'ok' | 'syncing' | 'degraded' {
+  if (!pgConnected) return 'degraded';
+  if (lastProcessedBlock === 0) return 'syncing';
+  if (!redisConnected) return 'degraded';
+  return 'ok';
+}
+
+export async function registerHealthRoutes(server: FastifyInstance): Promise<void> {
+  const config = getConfig();
+
+  // Liveness — returns 200 if the process is running
+  server.get('/v1/health', async (_request, reply) => {
+    const pgConnected = await checkPostgres();
+    const redisConnected = isRedisReady();
+
+    let lastProcessedBlock = 0;
+    try {
+      lastProcessedBlock = await getLastProcessedBlock();
+    } catch {
+      // If we can't read state, report 0
+    }
+
+    const indexerHeight = _indexerBlockHeight;
+    const blockLag = indexerHeight !== null ? indexerHeight - lastProcessedBlock : null;
+
+    const status = computeStatus(lastProcessedBlock, pgConnected, redisConnected);
+
+    const response: HealthResponse = {
+      status,
+      lastProcessedBlock,
+      indexerBlockHeight: indexerHeight,
+      blockLag,
+      instanceRole: config.INSTANCE_ROLE,
+      postgresConnected: pgConnected,
+      redisConnected,
+    };
+
+    return reply.send(response);
+  });
+
+  // Readiness — returns 200 only if initial sync complete and PostgreSQL reachable
+  server.get('/v1/health/ready', async (_request, reply) => {
+    const pgConnected = await checkPostgres();
+    if (!pgConnected) {
+      return reply.status(503).send({
+        error: 'Service Unavailable',
+        message: 'PostgreSQL is not reachable',
+      });
+    }
+
+    let lastProcessedBlock = 0;
+    try {
+      lastProcessedBlock = await getLastProcessedBlock();
+    } catch {
+      return reply.status(503).send({
+        error: 'Service Unavailable',
+        message: 'Unable to read resolver state',
+      });
+    }
+
+    if (lastProcessedBlock === 0) {
+      return reply.status(503).send({
+        error: 'Service Unavailable',
+        message: 'Resolver not yet synced (lastProcessedBlock = 0)',
+      });
+    }
+
+    return reply.send({ status: 'ready', lastProcessedBlock });
+  });
+}

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+
+// --- Mock dependencies ---
+
+vi.mock('../src/db/index.js', () => {
+  const mockQuery = vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] });
+  return {
+    getPool: vi.fn().mockReturnValue({
+      query: mockQuery,
+      connect: vi.fn().mockResolvedValue({
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+        release: vi.fn(),
+      }),
+    }),
+    query: mockQuery,
+  };
+});
+
+vi.mock('../src/cache/redis-client.js', () => ({
+  getRedis: vi.fn(),
+  connectRedis: vi.fn(),
+  disconnectRedis: vi.fn(),
+  isRedisReady: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../src/cache/file-cache.js', () => ({
+  getState: vi.fn().mockResolvedValue(null),
+  setState: vi.fn().mockResolvedValue(undefined),
+  getCachedFile: vi.fn().mockResolvedValue(null),
+  setCachedFile: vi.fn().mockResolvedValue(undefined),
+  deleteCachedFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../src/config/index.js', () => ({
+  loadConfig: vi.fn().mockReturnValue({
+    DATABASE_URL: 'postgresql://localhost/test',
+    REDIS_URL: 'redis://localhost:6379',
+    INSTANCE_ROLE: 'leader',
+    PORT: 3000,
+    LOG_LEVEL: 'info',
+    POLL_INTERVAL: 5,
+    CACHE_TTL: 86400,
+    TRUST_TTL: 3600,
+    POLL_OBJECT_CACHING_RETRY_DAYS: 7,
+    VPR_ALLOWLIST_PATH: 'config/vpr-allowlist.json',
+  }),
+  getConfig: vi.fn().mockReturnValue({
+    DATABASE_URL: 'postgresql://localhost/test',
+    REDIS_URL: 'redis://localhost:6379',
+    INSTANCE_ROLE: 'leader',
+    PORT: 3000,
+    LOG_LEVEL: 'info',
+    POLL_INTERVAL: 5,
+    CACHE_TTL: 86400,
+    TRUST_TTL: 3600,
+    POLL_OBJECT_CACHING_RETRY_DAYS: 7,
+    VPR_ALLOWLIST_PATH: 'config/vpr-allowlist.json',
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /v1/health', () => {
+  it('returns ok status when postgres and redis are connected and block > 0', async () => {
+    const { getState } = await import('../src/cache/file-cache.js');
+    vi.mocked(getState).mockResolvedValueOnce('42');
+
+    const { registerHealthRoutes, setIndexerBlockHeight } = await import('../src/routes/health.js');
+    setIndexerBlockHeight(50);
+
+    const server = Fastify({ logger: false });
+    await registerHealthRoutes(server);
+    await server.ready();
+
+    const response = await server.inject({ method: 'GET', url: '/v1/health' });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.status).toBe('ok');
+    expect(body.lastProcessedBlock).toBe(42);
+    expect(body.indexerBlockHeight).toBe(50);
+    expect(body.blockLag).toBe(8);
+    expect(body.instanceRole).toBe('leader');
+    expect(body.postgresConnected).toBe(true);
+    expect(body.redisConnected).toBe(true);
+
+    await server.close();
+  });
+
+  it('returns syncing status when lastProcessedBlock is 0', async () => {
+    const { getState } = await import('../src/cache/file-cache.js');
+    vi.mocked(getState).mockResolvedValueOnce(null);
+
+    const { getPool } = await import('../src/db/index.js');
+    vi.mocked(getPool().query as any).mockResolvedValueOnce({ rows: [{ '?column?': 1 }] });
+    vi.mocked(getPool().query as any).mockResolvedValueOnce({ rows: [] });
+
+    const { registerHealthRoutes } = await import('../src/routes/health.js');
+
+    const server = Fastify({ logger: false });
+    await registerHealthRoutes(server);
+    await server.ready();
+
+    const response = await server.inject({ method: 'GET', url: '/v1/health' });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.status).toBe('syncing');
+    expect(body.lastProcessedBlock).toBe(0);
+
+    await server.close();
+  });
+
+  it('returns degraded status when postgres is down', async () => {
+    const { getPool } = await import('../src/db/index.js');
+    vi.mocked(getPool().query as any).mockRejectedValueOnce(new Error('connection refused'));
+
+    const { registerHealthRoutes } = await import('../src/routes/health.js');
+
+    const server = Fastify({ logger: false });
+    await registerHealthRoutes(server);
+    await server.ready();
+
+    const response = await server.inject({ method: 'GET', url: '/v1/health' });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.status).toBe('degraded');
+    expect(body.postgresConnected).toBe(false);
+
+    await server.close();
+  });
+
+  it('returns degraded status when redis is down', async () => {
+    const { isRedisReady } = await import('../src/cache/redis-client.js');
+    vi.mocked(isRedisReady).mockReturnValueOnce(false);
+
+    const { getState } = await import('../src/cache/file-cache.js');
+    vi.mocked(getState).mockResolvedValueOnce(null);
+
+    const { getPool } = await import('../src/db/index.js');
+    vi.mocked(getPool().query as any).mockResolvedValueOnce({ rows: [{ '?column?': 1 }] });
+    vi.mocked(getPool().query as any).mockResolvedValueOnce({ rows: [{ value: '10' }] });
+
+    const { registerHealthRoutes } = await import('../src/routes/health.js');
+
+    const server = Fastify({ logger: false });
+    await registerHealthRoutes(server);
+    await server.ready();
+
+    const response = await server.inject({ method: 'GET', url: '/v1/health' });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.status).toBe('degraded');
+    expect(body.redisConnected).toBe(false);
+
+    await server.close();
+  });
+});
+
+describe('GET /v1/health/ready', () => {
+  it('returns 200 when synced and postgres connected', async () => {
+    const { getState } = await import('../src/cache/file-cache.js');
+    vi.mocked(getState).mockResolvedValueOnce('100');
+
+    const { registerHealthRoutes } = await import('../src/routes/health.js');
+
+    const server = Fastify({ logger: false });
+    await registerHealthRoutes(server);
+    await server.ready();
+
+    const response = await server.inject({ method: 'GET', url: '/v1/health/ready' });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(body.status).toBe('ready');
+    expect(body.lastProcessedBlock).toBe(100);
+
+    await server.close();
+  });
+
+  it('returns 503 when not yet synced (block = 0)', async () => {
+    const { getState } = await import('../src/cache/file-cache.js');
+    vi.mocked(getState).mockResolvedValueOnce(null);
+
+    const { getPool } = await import('../src/db/index.js');
+    vi.mocked(getPool().query as any).mockResolvedValueOnce({ rows: [{ '?column?': 1 }] });
+    vi.mocked(getPool().query as any).mockResolvedValueOnce({ rows: [] });
+
+    const { registerHealthRoutes } = await import('../src/routes/health.js');
+
+    const server = Fastify({ logger: false });
+    await registerHealthRoutes(server);
+    await server.ready();
+
+    const response = await server.inject({ method: 'GET', url: '/v1/health/ready' });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(503);
+    expect(body.error).toBe('Service Unavailable');
+
+    await server.close();
+  });
+
+  it('returns 503 when postgres is unreachable', async () => {
+    const { getPool } = await import('../src/db/index.js');
+    vi.mocked(getPool().query as any).mockRejectedValueOnce(new Error('connection refused'));
+
+    const { registerHealthRoutes } = await import('../src/routes/health.js');
+
+    const server = Fastify({ logger: false });
+    await registerHealthRoutes(server);
+    await server.ready();
+
+    const response = await server.inject({ method: 'GET', url: '/v1/health/ready' });
+    const body = JSON.parse(response.body);
+
+    expect(response.statusCode).toBe(503);
+    expect(body.message).toContain('PostgreSQL');
+
+    await server.close();
+  });
+});


### PR DESCRIPTION
## Summary

Implements health/readiness endpoints and Prometheus-compatible observability infrastructure.

### New endpoints

- **`GET /v1/health`** — Liveness check returning:\n  - `status`: `ok` | `syncing` | `degraded`\n  - `lastProcessedBlock`, `indexerBlockHeight`, `blockLag`\n  - `instanceRole`: `leader` | `reader`\n  - `postgresConnected`, `redisConnected`\n\n- **`GET /v1/health/ready`** — Readiness check:\n  - 200 if `lastProcessedBlock > 0` and PostgreSQL reachable\n  - 503 otherwise\n\n- **`GET /metrics`** — Prometheus-compatible metrics

### Metrics defined

| Metric | Type | Description |
|---|---|---|
| `resolver_last_processed_block` | Gauge | Last block height processed |
| `resolver_block_lag` | Gauge | Indexer height − last processed block |
| `resolver_reattemptable_count` | Gauge | Resources in reattemptable table |
| `resolver_trust_evaluations_total` | Counter | Total trust evaluations |
| `resolver_redis_hits_total` | Counter | Redis cache hits |
| `resolver_redis_misses_total` | Counter | Redis cache misses |
| `resolver_indexer_calls_total` | Counter | Indexer API calls (by endpoint) |
| `resolver_query_duration_seconds` | Histogram | HTTP request duration (by endpoint, status) |

### Files

- **New**: `src/observability/metrics.ts`, `src/routes/health.ts`, `test/health.test.ts`
- **Modified**: `src/index.ts` (register health routes, metrics endpoint, onResponse hook), `package.json` (+`prom-client`)

### Tests

7 tests covering all health/readiness scenarios (ok, syncing, degraded, pg down, redis down, ready, not ready).

All 126 tests pass locally (`tsc --noEmit` + `vitest run`).

Closes #24