### PR TITLE
ci: add PR checks workflow (typecheck + tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node v22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Problem

Tests and typecheck only run on push to main (inside `dev-release.yml`), meaning bugs can slip through PRs undetected.

## Fix

Adds `.github/workflows/ci.yml` that runs on every PR targeting `main`:

1. `npm install`
2. `tsc --noEmit` (typecheck)
3. `npm test` (vitest)

This matches exactly what we run locally before pushing.