### PR TITLE
feat: replace DATABASE_URL with POSTGRES_* vars, add INDEXER_API and ECS_ECOSYSTEM_DIDS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,15 @@
 # ===========================================
 
 # --- Required ---
-DATABASE_URL=postgresql://user:password@localhost:5432/verana_resolver
+POSTGRES_HOST=localhost
+POSTGRES_USER=verana
+POSTGRES_PASSWORD=verana
+POSTGRES_DB=verana_resolver
 REDIS_URL=redis://localhost:6379
+INDEXER_API=http://localhost:1317
 
 # --- Optional (defaults shown) ---
+POSTGRES_PORT=5432
 PORT=3000
 LOG_LEVEL=info
 INSTANCE_ROLE=leader
@@ -14,4 +19,4 @@ POLL_INTERVAL=5
 CACHE_TTL=86400
 TRUST_TTL=3600
 POLL_OBJECT_CACHING_RETRY_DAYS=7
-VPR_ALLOWLIST_PATH=config/vpr-allowlist.json
+ECS_ECOSYSTEM_DIDS=did:web:ecosystem1.example.com,did:web:ecosystem2.example.com

--- a/README.md
+++ b/README.md
@@ -27,13 +27,18 @@ The **Verana Trust Resolver** is a core infrastructure component of the [Verana]
 
 | Variable | Description |
 |---|---|
-| `DATABASE_URL` | PostgreSQL connection string (e.g. `postgresql://user:pass@host:5432/db`) |
+| `POSTGRES_HOST` | PostgreSQL host address |
+| `POSTGRES_USER` | PostgreSQL username |
+| `POSTGRES_PASSWORD` | PostgreSQL password |
+| `POSTGRES_DB` | PostgreSQL database name |
 | `REDIS_URL` | Redis connection string (e.g. `redis://host:6379`) |
+| `INDEXER_API` | URL of the Verana Indexer API (e.g. `http://indexer:1317`) |
 
 ### Optional
 
 | Variable | Default | Description |
 |---|---|---|
+| `POSTGRES_PORT` | `5432` | PostgreSQL port |
 | `PORT` | `3000` | HTTP listen port |
 | `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 | `INSTANCE_ROLE` | `leader` | Instance role: `leader` (runs polling loop) or `reader` (API-only) |
@@ -41,7 +46,7 @@ The **Verana Trust Resolver** is a core infrastructure component of the [Verana]
 | `CACHE_TTL` | `86400` | Dereferenced object cache TTL in seconds (24h) |
 | `TRUST_TTL` | `3600` | Trust evaluation result TTL in seconds (1h) |
 | `POLL_OBJECT_CACHING_RETRY_DAYS` | `7` | Maximum retry window for failed dereferencing (days) |
-| `VPR_ALLOWLIST_PATH` | `config/vpr-allowlist.json` | Path to the VPR allowlist configuration file |
+| `ECS_ECOSYSTEM_DIDS` | *(empty)* | Comma-separated list of allowed ECS ecosystem DIDs |
 
 ## Tech Stack
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -39,16 +39,21 @@ This chart deploys the Verana Trust Resolver (Fastify) as a Deployment with a Se
 
 Defined under `env` with testnet reference values; override per environment:
 
-- `DATABASE_URL` — PostgreSQL connection string
+- `POSTGRES_HOST` — PostgreSQL host address
+- `POSTGRES_PORT` — PostgreSQL port (default: 5432)
+- `POSTGRES_USER` — PostgreSQL username
+- `POSTGRES_PASSWORD` — PostgreSQL password
+- `POSTGRES_DB` — PostgreSQL database name
 - `REDIS_URL` — Redis connection string
+- `INDEXER_API` — URL of the Verana Indexer API
 - `PORT` — Server port (default: 3000)
 - `LOG_LEVEL` — Pino log level (default: info)
-- `POLL_INTERVAL` — Indexer polling interval in ms (default: 5000)
-- `CACHE_TTL` — Cache TTL in seconds (default: 300)
+- `INSTANCE_ROLE` — Instance role: leader or reader (default: leader)
+- `POLL_INTERVAL` — Indexer polling interval in seconds (default: 5)
+- `CACHE_TTL` — Cache TTL in seconds (default: 86400)
 - `TRUST_TTL` — Trust evaluation TTL in seconds (default: 3600)
-- `RETRY_MAX_ATTEMPTS` — Max retry attempts for failed DIDs (default: 5)
-- `RETRY_BASE_DELAY` — Base delay between retries in seconds (default: 60)
-- `VPR_ALLOWLIST_PATH` — Path to VPR allowlist JSON (default: ./config/vpr-allowlist.json)
+- `POLL_OBJECT_CACHING_RETRY_DAYS` — Max retry window in days (default: 7)
+- `ECS_ECOSYSTEM_DIDS` — Comma-separated list of allowed ECS ecosystem DIDs
 
 ### Quick examples
 
@@ -63,6 +68,10 @@ Install/upgrade (override image tag and env vars):
 ```bash
 helm upgrade --install verana-resolver ./charts \
   -n vna-testnet-1 \
-  --set env.DATABASE_URL=postgresql://user:pass@db:5432/resolver \
-  --set env.REDIS_URL=redis://redis:6379
+  --set env.POSTGRES_HOST=db \
+  --set env.POSTGRES_USER=verana \
+  --set env.POSTGRES_PASSWORD=secret \
+  --set env.POSTGRES_DB=verana_resolver \
+  --set env.REDIS_URL=redis://redis:6379 \
+  --set env.INDEXER_API=http://indexer:1317
 ```

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -24,16 +24,21 @@ nodeSelector:
 
 # Environment variables consumed by the application
 env:
-  DATABASE_URL: "postgresql://verana:verana@localhost:5432/verana_resolver"
+  POSTGRES_HOST: "localhost"
+  POSTGRES_PORT: "5432"
+  POSTGRES_USER: "verana"
+  POSTGRES_PASSWORD: "verana"
+  POSTGRES_DB: "verana_resolver"
   REDIS_URL: "redis://localhost:6379"
+  INDEXER_API: "http://localhost:1317"
   PORT: "3000"
   LOG_LEVEL: "info"
-  POLL_INTERVAL: "5000"
-  CACHE_TTL: "300"
+  INSTANCE_ROLE: "leader"
+  POLL_INTERVAL: "5"
+  CACHE_TTL: "86400"
   TRUST_TTL: "3600"
-  RETRY_MAX_ATTEMPTS: "5"
-  RETRY_BASE_DELAY: "60"
-  VPR_ALLOWLIST_PATH: "./config/vpr-allowlist.json"
+  POLL_OBJECT_CACHING_RETRY_DAYS: "7"
+  ECS_ECOSYSTEM_DIDS: ""
 
 # Additional env variables if needed (list of {name, value})
 extraEnv: []

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,12 @@ set -e
 
 # Validate required environment variables
 REQUIRED_VARS="
-DATABASE_URL
+POSTGRES_HOST
+POSTGRES_USER
+POSTGRES_PASSWORD
+POSTGRES_DB
 REDIS_URL
+INDEXER_API
 "
 
 echo "Validating environment variables..."

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,17 +10,25 @@ const envSchema = z.object({
   TRUST_TTL: z.coerce.number().int().positive().default(3600),
   POLL_OBJECT_CACHING_RETRY_DAYS: z.coerce.number().int().positive().default(7),
 
+  // PostgreSQL
+  POSTGRES_HOST: z.string(),
+  POSTGRES_PORT: z.coerce.number().int().positive().default(5432),
+  POSTGRES_USER: z.string(),
+  POSTGRES_PASSWORD: z.string(),
+  POSTGRES_DB: z.string(),
+
   // Infrastructure
-  DATABASE_URL: z.string().url(),
   REDIS_URL: z.string().url(),
   INSTANCE_ROLE: InstanceRole.default('leader'),
+
+  // Indexer
+  INDEXER_API: z.string().url(),
+  ECS_ECOSYSTEM_DIDS: z.string().default(''),
 
   // Server
   PORT: z.coerce.number().int().positive().default(3000),
   LOG_LEVEL: LogLevel.default('info'),
 
-  // VPR allowlist
-  VPR_ALLOWLIST_PATH: z.string().default('config/vpr-allowlist.json'),
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -9,7 +9,11 @@ export function getPool(): pg.Pool {
   if (_pool === null) {
     const config = getConfig();
     _pool = new Pool({
-      connectionString: config.DATABASE_URL,
+      host: config.POSTGRES_HOST,
+      port: config.POSTGRES_PORT,
+      user: config.POSTGRES_USER,
+      password: config.POSTGRES_PASSWORD,
+      database: config.POSTGRES_DB,
       max: 20,
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 5000,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -4,9 +4,14 @@ import { loadConfig } from '../src/config/index.js';
 describe('loadConfig', () => {
   it('loads valid configuration from env', () => {
     const config = loadConfig({
-      DATABASE_URL: 'postgresql://localhost:5432/test',
+      POSTGRES_HOST: 'localhost',
+      POSTGRES_USER: 'verana',
+      POSTGRES_PASSWORD: 'verana',
+      POSTGRES_DB: 'verana_resolver',
       REDIS_URL: 'redis://localhost:6379',
+      INDEXER_API: 'http://localhost:1317',
     });
+    expect(config.POSTGRES_PORT).toBe(5432);
     expect(config.POLL_INTERVAL).toBe(5);
     expect(config.CACHE_TTL).toBe(86400);
     expect(config.TRUST_TTL).toBe(3600);
@@ -14,31 +19,45 @@ describe('loadConfig', () => {
     expect(config.INSTANCE_ROLE).toBe('leader');
     expect(config.PORT).toBe(3000);
     expect(config.LOG_LEVEL).toBe('info');
+    expect(config.ECS_ECOSYSTEM_DIDS).toBe('');
   });
 
   it('overrides defaults with provided values', () => {
     const config = loadConfig({
-      DATABASE_URL: 'postgresql://localhost:5432/test',
+      POSTGRES_HOST: 'db.example.com',
+      POSTGRES_PORT: '5433',
+      POSTGRES_USER: 'admin',
+      POSTGRES_PASSWORD: 'secret',
+      POSTGRES_DB: 'mydb',
       REDIS_URL: 'redis://localhost:6379',
+      INDEXER_API: 'http://indexer:1317',
       POLL_INTERVAL: '10',
       CACHE_TTL: '43200',
       TRUST_TTL: '1800',
       INSTANCE_ROLE: 'reader',
       PORT: '8080',
       LOG_LEVEL: 'debug',
+      ECS_ECOSYSTEM_DIDS: 'did:web:eco1.example.com,did:web:eco2.example.com',
     });
+    expect(config.POSTGRES_HOST).toBe('db.example.com');
+    expect(config.POSTGRES_PORT).toBe(5433);
     expect(config.POLL_INTERVAL).toBe(10);
     expect(config.CACHE_TTL).toBe(43200);
     expect(config.TRUST_TTL).toBe(1800);
     expect(config.INSTANCE_ROLE).toBe('reader');
     expect(config.PORT).toBe(8080);
     expect(config.LOG_LEVEL).toBe('debug');
+    expect(config.ECS_ECOSYSTEM_DIDS).toBe('did:web:eco1.example.com,did:web:eco2.example.com');
   });
 
-  it('throws on missing required DATABASE_URL', () => {
+  it('throws on missing required POSTGRES_HOST', () => {
     expect(() =>
       loadConfig({
+        POSTGRES_USER: 'verana',
+        POSTGRES_PASSWORD: 'verana',
+        POSTGRES_DB: 'verana_resolver',
         REDIS_URL: 'redis://localhost:6379',
+        INDEXER_API: 'http://localhost:1317',
       }),
     ).toThrow('Invalid configuration');
   });
@@ -46,7 +65,23 @@ describe('loadConfig', () => {
   it('throws on missing required REDIS_URL', () => {
     expect(() =>
       loadConfig({
-        DATABASE_URL: 'postgresql://localhost:5432/test',
+        POSTGRES_HOST: 'localhost',
+        POSTGRES_USER: 'verana',
+        POSTGRES_PASSWORD: 'verana',
+        POSTGRES_DB: 'verana_resolver',
+        INDEXER_API: 'http://localhost:1317',
+      }),
+    ).toThrow('Invalid configuration');
+  });
+
+  it('throws on missing required INDEXER_API', () => {
+    expect(() =>
+      loadConfig({
+        POSTGRES_HOST: 'localhost',
+        POSTGRES_USER: 'verana',
+        POSTGRES_PASSWORD: 'verana',
+        POSTGRES_DB: 'verana_resolver',
+        REDIS_URL: 'redis://localhost:6379',
       }),
     ).toThrow('Invalid configuration');
   });
@@ -54,8 +89,12 @@ describe('loadConfig', () => {
   it('throws on invalid INSTANCE_ROLE', () => {
     expect(() =>
       loadConfig({
-        DATABASE_URL: 'postgresql://localhost:5432/test',
+        POSTGRES_HOST: 'localhost',
+        POSTGRES_USER: 'verana',
+        POSTGRES_PASSWORD: 'verana',
+        POSTGRES_DB: 'verana_resolver',
         REDIS_URL: 'redis://localhost:6379',
+        INDEXER_API: 'http://localhost:1317',
         INSTANCE_ROLE: 'invalid',
       }),
     ).toThrow('Invalid configuration');

--- a/test/db-client.test.ts
+++ b/test/db-client.test.ts
@@ -4,24 +4,38 @@ import { loadConfig } from '../src/config/index.js';
 describe('db client configuration', () => {
   beforeEach(() => {
     loadConfig({
-      DATABASE_URL: 'postgresql://localhost:5432/verana_resolver_test',
+      POSTGRES_HOST: 'localhost',
+      POSTGRES_USER: 'verana',
+      POSTGRES_PASSWORD: 'verana',
+      POSTGRES_DB: 'verana_resolver_test',
       REDIS_URL: 'redis://localhost:6379',
+      INDEXER_API: 'http://localhost:1317',
     });
   });
 
-  it('config includes DATABASE_URL', () => {
+  it('config includes POSTGRES_* vars', () => {
     const config = loadConfig({
-      DATABASE_URL: 'postgresql://localhost:5432/verana_resolver_test',
+      POSTGRES_HOST: 'localhost',
+      POSTGRES_PORT: '5432',
+      POSTGRES_USER: 'verana',
+      POSTGRES_PASSWORD: 'verana',
+      POSTGRES_DB: 'verana_resolver_test',
       REDIS_URL: 'redis://localhost:6379',
+      INDEXER_API: 'http://localhost:1317',
     });
-    expect(config.DATABASE_URL).toBe('postgresql://localhost:5432/verana_resolver_test');
+    expect(config.POSTGRES_HOST).toBe('localhost');
+    expect(config.POSTGRES_PORT).toBe(5432);
+    expect(config.POSTGRES_DB).toBe('verana_resolver_test');
   });
 
-  it('rejects invalid DATABASE_URL', () => {
+  it('rejects missing POSTGRES_HOST', () => {
     expect(() =>
       loadConfig({
-        DATABASE_URL: 'not-a-url',
+        POSTGRES_USER: 'verana',
+        POSTGRES_PASSWORD: 'verana',
+        POSTGRES_DB: 'verana_resolver_test',
         REDIS_URL: 'redis://localhost:6379',
+        INDEXER_API: 'http://localhost:1317',
       }),
     ).toThrow('Invalid configuration');
   });

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -34,8 +34,13 @@ vi.mock('../src/cache/file-cache.js', () => ({
 
 vi.mock('../src/config/index.js', () => ({
   loadConfig: vi.fn().mockReturnValue({
-    DATABASE_URL: 'postgresql://localhost/test',
+    POSTGRES_HOST: 'localhost',
+    POSTGRES_PORT: 5432,
+    POSTGRES_USER: 'verana',
+    POSTGRES_PASSWORD: 'verana',
+    POSTGRES_DB: 'test',
     REDIS_URL: 'redis://localhost:6379',
+    INDEXER_API: 'http://localhost:1317',
     INSTANCE_ROLE: 'leader',
     PORT: 3000,
     LOG_LEVEL: 'info',
@@ -43,11 +48,16 @@ vi.mock('../src/config/index.js', () => ({
     CACHE_TTL: 86400,
     TRUST_TTL: 3600,
     POLL_OBJECT_CACHING_RETRY_DAYS: 7,
-    VPR_ALLOWLIST_PATH: 'config/vpr-allowlist.json',
+    ECS_ECOSYSTEM_DIDS: '',
   }),
   getConfig: vi.fn().mockReturnValue({
-    DATABASE_URL: 'postgresql://localhost/test',
+    POSTGRES_HOST: 'localhost',
+    POSTGRES_PORT: 5432,
+    POSTGRES_USER: 'verana',
+    POSTGRES_PASSWORD: 'verana',
+    POSTGRES_DB: 'test',
     REDIS_URL: 'redis://localhost:6379',
+    INDEXER_API: 'http://localhost:1317',
     INSTANCE_ROLE: 'leader',
     PORT: 3000,
     LOG_LEVEL: 'info',
@@ -55,7 +65,7 @@ vi.mock('../src/config/index.js', () => ({
     CACHE_TTL: 86400,
     TRUST_TTL: 3600,
     POLL_OBJECT_CACHING_RETRY_DAYS: 7,
-    VPR_ALLOWLIST_PATH: 'config/vpr-allowlist.json',
+    ECS_ECOSYSTEM_DIDS: '',
   }),
 }));
 


### PR DESCRIPTION
## Summary\n\nImproves env variable flexibility per #58.\n\n### Breaking changes\n\n- **`DATABASE_URL`** replaced by individual PostgreSQL vars:\n  - `POSTGRES_HOST` (required)\n  - `POSTGRES_PORT` (default: 5432)\n  - `POSTGRES_USER` (required)\n  - `POSTGRES_PASSWORD` (required)\n  - `POSTGRES_DB` (required)\n\n- **`VPR_ALLOWLIST_PATH`** removed — replaced by:\n  - `INDEXER_API` (required) — URL of the Verana Indexer\n  - `ECS_ECOSYSTEM_DIDS` (optional) — comma-separated list of allowed ECS ecosystem DIDs\n\n### Files changed\n\n**Source:**\n- `src/config/index.ts` — new env schema\n- `src/db/client.ts` — uses individual PG vars instead of connection string\n- `src/index.ts` — uses `INDEXER_API` directly, removes vpr-allowlist dependency\n\n**Config/docs:**\n- `entrypoint.sh` — validates new required vars\n- `.env.example` — updated\n- `README.md` — updated env var tables\n\n**Helm:**\n- `charts/values.yaml` — all env vars updated\n- `charts/README.md` — updated docs and examples\n\n**Tests:**\n- `test/config.test.ts` — 6 tests (added INDEXER_API missing test)\n- `test/db-client.test.ts` — updated to POSTGRES_* vars\n- `test/health.test.ts` — updated mock config\n\nAll 127 tests pass locally (`tsc --noEmit` + `vitest run`).\n\nCloses #58