### PR TITLE
fix: make ECS_ECOSYSTEM_DIDS a required environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ POSTGRES_PASSWORD=verana
 POSTGRES_DB=verana_resolver
 REDIS_URL=redis://localhost:6379
 INDEXER_API=http://localhost:1317
+ECS_ECOSYSTEM_DIDS=did:web:ecosystem1.example.com,did:web:ecosystem2.example.com
 
 # --- Optional (defaults shown) ---
 POSTGRES_PORT=5432
@@ -19,4 +20,3 @@ POLL_INTERVAL=5
 CACHE_TTL=86400
 TRUST_TTL=3600
 POLL_OBJECT_CACHING_RETRY_DAYS=7
-ECS_ECOSYSTEM_DIDS=did:web:ecosystem1.example.com,did:web:ecosystem2.example.com

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The **Verana Trust Resolver** is a core infrastructure component of the [Verana]
 | `POSTGRES_DB` | PostgreSQL database name |
 | `REDIS_URL` | Redis connection string (e.g. `redis://host:6379`) |
 | `INDEXER_API` | URL of the Verana Indexer API (e.g. `http://indexer:1317`) |
+| `ECS_ECOSYSTEM_DIDS` | Comma-separated list of allowed ECS ecosystem DIDs |
 
 ### Optional
 
@@ -46,7 +47,6 @@ The **Verana Trust Resolver** is a core infrastructure component of the [Verana]
 | `CACHE_TTL` | `86400` | Dereferenced object cache TTL in seconds (24h) |
 | `TRUST_TTL` | `3600` | Trust evaluation result TTL in seconds (1h) |
 | `POLL_OBJECT_CACHING_RETRY_DAYS` | `7` | Maximum retry window for failed dereferencing (days) |
-| `ECS_ECOSYSTEM_DIDS` | *(empty)* | Comma-separated list of allowed ECS ecosystem DIDs |
 
 ## Tech Stack
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,7 @@ POSTGRES_PASSWORD
 POSTGRES_DB
 REDIS_URL
 INDEXER_API
+ECS_ECOSYSTEM_DIDS
 "
 
 echo "Validating environment variables..."

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,7 +23,7 @@ const envSchema = z.object({
 
   // Indexer
   INDEXER_API: z.string().url(),
-  ECS_ECOSYSTEM_DIDS: z.string().default(''),
+  ECS_ECOSYSTEM_DIDS: z.string().min(1),
 
   // Server
   PORT: z.coerce.number().int().positive().default(3000),

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -10,6 +10,7 @@ describe('loadConfig', () => {
       POSTGRES_DB: 'verana_resolver',
       REDIS_URL: 'redis://localhost:6379',
       INDEXER_API: 'http://localhost:1317',
+      ECS_ECOSYSTEM_DIDS: 'did:web:ecosystem.example.com',
     });
     expect(config.POSTGRES_PORT).toBe(5432);
     expect(config.POLL_INTERVAL).toBe(5);
@@ -19,7 +20,7 @@ describe('loadConfig', () => {
     expect(config.INSTANCE_ROLE).toBe('leader');
     expect(config.PORT).toBe(3000);
     expect(config.LOG_LEVEL).toBe('info');
-    expect(config.ECS_ECOSYSTEM_DIDS).toBe('');
+    expect(config.ECS_ECOSYSTEM_DIDS).toBe('did:web:ecosystem.example.com');
   });
 
   it('overrides defaults with provided values', () => {
@@ -58,6 +59,7 @@ describe('loadConfig', () => {
         POSTGRES_DB: 'verana_resolver',
         REDIS_URL: 'redis://localhost:6379',
         INDEXER_API: 'http://localhost:1317',
+        ECS_ECOSYSTEM_DIDS: 'did:web:ecosystem.example.com',
       }),
     ).toThrow('Invalid configuration');
   });
@@ -70,6 +72,7 @@ describe('loadConfig', () => {
         POSTGRES_PASSWORD: 'verana',
         POSTGRES_DB: 'verana_resolver',
         INDEXER_API: 'http://localhost:1317',
+        ECS_ECOSYSTEM_DIDS: 'did:web:ecosystem.example.com',
       }),
     ).toThrow('Invalid configuration');
   });
@@ -82,6 +85,20 @@ describe('loadConfig', () => {
         POSTGRES_PASSWORD: 'verana',
         POSTGRES_DB: 'verana_resolver',
         REDIS_URL: 'redis://localhost:6379',
+        ECS_ECOSYSTEM_DIDS: 'did:web:ecosystem.example.com',
+      }),
+    ).toThrow('Invalid configuration');
+  });
+
+  it('throws on missing required ECS_ECOSYSTEM_DIDS', () => {
+    expect(() =>
+      loadConfig({
+        POSTGRES_HOST: 'localhost',
+        POSTGRES_USER: 'verana',
+        POSTGRES_PASSWORD: 'verana',
+        POSTGRES_DB: 'verana_resolver',
+        REDIS_URL: 'redis://localhost:6379',
+        INDEXER_API: 'http://localhost:1317',
       }),
     ).toThrow('Invalid configuration');
   });
@@ -95,6 +112,7 @@ describe('loadConfig', () => {
         POSTGRES_DB: 'verana_resolver',
         REDIS_URL: 'redis://localhost:6379',
         INDEXER_API: 'http://localhost:1317',
+        ECS_ECOSYSTEM_DIDS: 'did:web:ecosystem.example.com',
         INSTANCE_ROLE: 'invalid',
       }),
     ).toThrow('Invalid configuration');

--- a/test/db-client.test.ts
+++ b/test/db-client.test.ts
@@ -10,6 +10,7 @@ describe('db client configuration', () => {
       POSTGRES_DB: 'verana_resolver_test',
       REDIS_URL: 'redis://localhost:6379',
       INDEXER_API: 'http://localhost:1317',
+      ECS_ECOSYSTEM_DIDS: 'did:web:ecosystem.example.com',
     });
   });
 
@@ -22,6 +23,7 @@ describe('db client configuration', () => {
       POSTGRES_DB: 'verana_resolver_test',
       REDIS_URL: 'redis://localhost:6379',
       INDEXER_API: 'http://localhost:1317',
+      ECS_ECOSYSTEM_DIDS: 'did:web:ecosystem.example.com',
     });
     expect(config.POSTGRES_HOST).toBe('localhost');
     expect(config.POSTGRES_PORT).toBe(5432);
@@ -36,6 +38,7 @@ describe('db client configuration', () => {
         POSTGRES_DB: 'verana_resolver_test',
         REDIS_URL: 'redis://localhost:6379',
         INDEXER_API: 'http://localhost:1317',
+        ECS_ECOSYSTEM_DIDS: 'did:web:ecosystem.example.com',
       }),
     ).toThrow('Invalid configuration');
   });

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -48,7 +48,7 @@ vi.mock('../src/config/index.js', () => ({
     CACHE_TTL: 86400,
     TRUST_TTL: 3600,
     POLL_OBJECT_CACHING_RETRY_DAYS: 7,
-    ECS_ECOSYSTEM_DIDS: '',
+    ECS_ECOSYSTEM_DIDS: 'did:web:ecosystem.example.com',
   }),
   getConfig: vi.fn().mockReturnValue({
     POSTGRES_HOST: 'localhost',
@@ -65,7 +65,7 @@ vi.mock('../src/config/index.js', () => ({
     CACHE_TTL: 86400,
     TRUST_TTL: 3600,
     POLL_OBJECT_CACHING_RETRY_DAYS: 7,
-    ECS_ECOSYSTEM_DIDS: '',
+    ECS_ECOSYSTEM_DIDS: 'did:web:ecosystem.example.com',
   }),
 }));
 


### PR DESCRIPTION
## Summary\n\n`ECS_ECOSYSTEM_DIDS` is required for evaluating trust from Verifiable Service (Q1). This was incorrectly set as optional with an empty default in #59.\n\n### Changes\n\n- **`src/config/index.ts`** — `ECS_ECOSYSTEM_DIDS: z.string().min(1)` (was `.default('')`)\n- **`entrypoint.sh`** — added `ECS_ECOSYSTEM_DIDS` to required vars\n- **`.env.example`** — moved to required section\n- **`README.md`** — moved to required env var table\n- **`test/config.test.ts`** — added `throws on missing required ECS_ECOSYSTEM_DIDS` test; all configs now provide it\n- **`test/db-client.test.ts`** — all configs now provide it\n- **`test/health.test.ts`** — mock configs updated\n\n128 tests pass (`tsc --noEmit` + `vitest run`).\n\nFollows up on #58 / #59.