### PR TITLE
fix: add missing Helm chart dependencies, PVCs, and StatefulSet

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -1,59 +1,93 @@
 # Verana Resolver Helm Chart
 
-This chart deploys the Verana Trust Resolver (Fastify) as a Deployment with a Service, optional ingress, configurable environment variables, and node scheduling controls.
+This chart deploys the Verana Trust Resolver as a StatefulSet with a Service, Ingress, persistent storage, and optional PostgreSQL and Redis sidecar containers.
 
 ## Features
 
-- Deploys the resolver with configurable image repo/tag and replica count.
-- Exposes the app via ClusterIP service; optional ingress block if you need it.
-- Captures all required env vars with override support.
-- Allows nodeSelector and resource overrides.
+- Deploys the resolver with configurable replicas and image tag
+- Optional PostgreSQL sidecar with PersistentVolumeClaim
+- Optional Redis sidecar with PersistentVolumeClaim
+- Public ingress with TLS via cert-manager
+- Configurable environment variables and resource limits
+- Node selector support
 
 ## Kubernetes Resources
 
-- Service (ClusterIP by default)
-- Deployment
-- Optional Ingress (disabled by default)
+- **Service** — exposes HTTP port, plus db/redis ports when sidecars are enabled
+- **Ingress** — public ingress with TLS
+- **PersistentVolumeClaim** — for PostgreSQL data (when `database.enabled: true`)
+- **PersistentVolumeClaim** — for Redis data (when `redis.enabled: true`)
+- **StatefulSet** — runs resolver container with optional PG/Redis sidecars
 
 ## Configuration
+
+### General
 
 | Parameter | Description | Default |
 | --- | --- | --- |
 | `name` | Application name/labels | `verana-resolver` |
 | `host` | Subdomain prefix | `resolver` |
-| `replicas` | Deployment replicas | `1` |
+| `replicas` | StatefulSet replicas | `1` |
 | `image.tag` | Image tag | `{{ .Chart.Version }}` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
-| `service.type` | Service type | `ClusterIP` |
 | `service.port` | Service port | `3000` |
 | `service.targetPort` | Container port | `3000` |
-| `nodeSelector` | Node selector map | `kubernetes.io/hostname: cluster-utc-node-07efe5` |
-| `env` | Required env vars (see below) | testnet defaults |
+| `nodeSelector` | Node selector map | see values.yaml |
+
+### Database Configuration (Optional)
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `database.enabled` | Enable PostgreSQL sidecar | `true` |
+| `database.host` | PostgreSQL host | `localhost` |
+| `database.port` | PostgreSQL port | `5432` |
+| `database.user` | PostgreSQL username | `verana` |
+| `database.password` | PostgreSQL password | `verana` |
+| `database.db` | PostgreSQL database name | `verana_resolver` |
+| `database.resources` | PostgreSQL container resources | `256Mi/100m` req, `512Mi/500m` limits |
+| `database.storage.size` | PVC size | `10Gi` |
+| `database.storage.storageClassName` | Storage class | `csi-cinder-classic` |
+
+### Redis Configuration (Optional)
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `redis.enabled` | Enable Redis sidecar | `true` |
+| `redis.host` | Redis host | `localhost` |
+| `redis.resources` | Redis container resources | `64Mi/25m` req, `128Mi/100m` limits |
+
+### Application Environment Variables
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `env.INDEXER_API` | URL of the Verana Indexer API | `http://localhost:1317` |
+| `env.ECS_ECOSYSTEM_DIDS` | Comma-separated allowed ecosystem DIDs | `""` |
+| `env.PORT` | Server port | `3000` |
+| `env.LOG_LEVEL` | Pino log level | `info` |
+| `env.INSTANCE_ROLE` | Instance role: leader or reader | `leader` |
+| `env.POLL_INTERVAL` | Polling interval in seconds | `5` |
+| `env.CACHE_TTL` | Cache TTL in seconds | `86400` |
+| `env.TRUST_TTL` | Trust evaluation TTL in seconds | `3600` |
+| `env.POLL_OBJECT_CACHING_RETRY_DAYS` | Max retry window in days | `7` |
 | `extraEnv` | Additional env entries (`[{name, value}]`) | `[]` |
-| `resources` | Pod resources | `512Mi/250m` requests, `1Gi/500m` limits |
-| `ingress.enabled` | Enable ingress | `true` |
 
-> **Note:** The image tag should match the Chart version by default to ensure deployment consistency. It can be overridden for debugging purposes if needed.
+> **Note:** `POSTGRES_*` and `REDIS_URL` env vars are automatically derived from `database.*` and `redis.*` config — do not set them under `env`.
 
-### Required environment variables
+### Resolver Container Resources
 
-Defined under `env` with testnet reference values; override per environment:
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `resources.requests.cpu` | Minimum reserved CPU | `250m` |
+| `resources.requests.memory` | Minimum reserved memory | `512Mi` |
+| `resources.limits.cpu` | Maximum allowed CPU | `500m` |
+| `resources.limits.memory` | Maximum allowed memory | `1Gi` |
 
-- `POSTGRES_HOST` — PostgreSQL host address
-- `POSTGRES_PORT` — PostgreSQL port (default: 5432)
-- `POSTGRES_USER` — PostgreSQL username
-- `POSTGRES_PASSWORD` — PostgreSQL password
-- `POSTGRES_DB` — PostgreSQL database name
-- `REDIS_URL` — Redis connection string
-- `INDEXER_API` — URL of the Verana Indexer API
-- `PORT` — Server port (default: 3000)
-- `LOG_LEVEL` — Pino log level (default: info)
-- `INSTANCE_ROLE` — Instance role: leader or reader (default: leader)
-- `POLL_INTERVAL` — Indexer polling interval in seconds (default: 5)
-- `CACHE_TTL` — Cache TTL in seconds (default: 86400)
-- `TRUST_TTL` — Trust evaluation TTL in seconds (default: 3600)
-- `POLL_OBJECT_CACHING_RETRY_DAYS` — Max retry window in days (default: 7)
-- `ECS_ECOSYSTEM_DIDS` — Comma-separated list of allowed ECS ecosystem DIDs
+### Ingress
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `ingress.host` | Ingress hostname (templated) | `resolver.testnet.verana.network` |
+| `ingress.public.enableCors` | Enable CORS for public ingress | `true` |
 
 ### Quick examples
 
@@ -63,15 +97,30 @@ Render:
 helm template ./charts
 ```
 
-Install/upgrade (override image tag and env vars):
+Install/upgrade:
 
 ```bash
 helm upgrade --install verana-resolver ./charts \
   -n vna-testnet-1 \
-  --set env.POSTGRES_HOST=db \
-  --set env.POSTGRES_USER=verana \
-  --set env.POSTGRES_PASSWORD=secret \
-  --set env.POSTGRES_DB=verana_resolver \
-  --set env.REDIS_URL=redis://redis:6379 \
-  --set env.INDEXER_API=http://indexer:1317
+  --set database.user=verana \
+  --set database.password=secret \
+  --set database.db=verana_resolver \
+  --set env.INDEXER_API=http://indexer:1317 \
+  --set env.ECS_ECOSYSTEM_DIDS=did:web:ecosystem.example.com
+```
+
+Disable sidecars (external PG/Redis):
+
+```bash
+helm upgrade --install verana-resolver ./charts \
+  -n vna-testnet-1 \
+  --set database.enabled=false \
+  --set database.host=external-db \
+  --set database.user=verana \
+  --set database.password=secret \
+  --set database.db=verana_resolver \
+  --set redis.enabled=false \
+  --set redis.host=external-redis \
+  --set env.INDEXER_API=http://indexer:1317 \
+  --set env.ECS_ECOSYSTEM_DIDS=did:web:ecosystem.example.com
 ```

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,59 +1,31 @@
+# Service deployment for Verana Resolver
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.name }}
 spec:
-  type: {{ .Values.service.type }}
   selector:
     app: {{ .Values.name }}
   ports:
-    - name: http
-      port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
-      protocol: TCP
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ .Values.name }}
-  labels:
-    app: {{ .Values.name }}
-spec:
-  replicas: {{ .Values.replicas }}
-  selector:
-    matchLabels:
-      app: {{ .Values.name }}
-  template:
-    metadata:
-      labels:
-        app: {{ .Values.name }}
-    spec:
-{{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+  - name: http
+    port: {{ .Values.service.port }}
+    targetPort: {{ .Values.service.targetPort }}
+    protocol: TCP
+{{- if .Values.database.enabled }}
+  - name: db
+    port: 5432
+    targetPort: 5432
+    protocol: TCP
 {{- end }}
-      containers:
-        - name: {{ .Values.name }}
-          image: veranalabs/verana-resolver:{{ tpl .Values.image.tag . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-{{- range $key, $value := .Values.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+{{- if .Values.redis.enabled }}
+  - name: redis
+    port: 6379
+    targetPort: 6379
+    protocol: TCP
 {{- end }}
-{{- range .Values.extraEnv }}
-            - name: {{ .name }}
-              value: {{ tpl .value $ | quote }}
-{{- end }}
-          ports:
-            - containerPort: {{ .Values.service.targetPort }}
-{{- if .Values.resources }}
-          resources:
-{{ toYaml .Values.resources | indent 12 }}
-{{- end }}
-{{- if .Values.ingress.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -80,4 +52,157 @@ spec:
                  name: {{ .Values.name }}
                  port:
                    number: {{ .Values.service.port }}
+---
+# PersistentVolumeClaim for the PostgreSQL database
+{{- if .Values.database.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.name }}-pg-pv-main
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  storageClassName: {{ .Values.database.storage.storageClassName | default "csi-cinder-classic" }}
+  resources:
+    requests:
+      storage: {{ .Values.database.storage.size | default "10Gi" }}
 {{- end }}
+---
+# PersistentVolumeClaim for Redis
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.name }}-redis-main
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  storageClassName: csi-cinder-classic
+  resources:
+    requests:
+      storage: 1Gi
+{{- end }}
+---
+# StatefulSet for the Verana Resolver
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+   name: {{ .Values.name }}
+   namespace: {{ .Release.Namespace }}
+spec:
+   serviceName: {{ .Values.name }}
+   replicas: {{ default 1 .Values.replicas }}
+   selector:
+      matchLabels:
+         app: {{ .Values.name }}
+   template:
+      metadata:
+         labels:
+            app: {{ .Values.name }}
+      spec:
+{{- if .Values.nodeSelector }}
+         nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 12 }}
+{{- end }}
+         containers:
+         -  name: {{ .Values.name }}-resolver-container
+            image: veranalabs/verana-resolver:{{ tpl .Values.image.tag . }}
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            {{- if .Values.resources }}
+            resources:
+{{- toYaml .Values.resources | nindent 14 }}
+            {{- end }}
+            env:
+              - name: POSTGRES_HOST
+                value: {{ .Values.database.host | quote }}
+              - name: POSTGRES_PORT
+                value: {{ .Values.database.port | default "5432" | quote }}
+              - name: POSTGRES_USER
+                value: {{ .Values.database.user | quote }}
+              - name: POSTGRES_PASSWORD
+                value: {{ .Values.database.password | quote }}
+              - name: POSTGRES_DB
+                value: {{ .Values.database.db | quote }}
+              - name: REDIS_URL
+                value: "redis://{{ .Values.redis.host }}:6379"
+              - name: INDEXER_API
+                value: {{ .Values.env.INDEXER_API | quote }}
+              - name: ECS_ECOSYSTEM_DIDS
+                value: {{ .Values.env.ECS_ECOSYSTEM_DIDS | quote }}
+              - name: PORT
+                value: {{ .Values.env.PORT | default "3000" | quote }}
+              - name: LOG_LEVEL
+                value: {{ .Values.env.LOG_LEVEL | default "info" | quote }}
+              - name: INSTANCE_ROLE
+                value: {{ .Values.env.INSTANCE_ROLE | default "leader" | quote }}
+              - name: POLL_INTERVAL
+                value: {{ .Values.env.POLL_INTERVAL | default "5" | quote }}
+              - name: CACHE_TTL
+                value: {{ .Values.env.CACHE_TTL | default "86400" | quote }}
+              - name: TRUST_TTL
+                value: {{ .Values.env.TRUST_TTL | default "3600" | quote }}
+              - name: POLL_OBJECT_CACHING_RETRY_DAYS
+                value: {{ .Values.env.POLL_OBJECT_CACHING_RETRY_DAYS | default "7" | quote }}
+{{- with .Values.extraEnv }}
+{{- range . }}
+              - name: {{ .name }}
+                value: {{ tpl .value $ | quote }}
+{{- end }}
+{{- end }}
+            ports:
+            -  containerPort: {{ .Values.service.targetPort }}
+        {{- if .Values.database.enabled }}
+         -  name: postgres
+            image: postgres:14-alpine
+            imagePullPolicy: Always
+            env:
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.database.password | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.database.user | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.database.db | quote }}
+            - name: PGDATA
+              value: "/var/lib/postgresql/data/pgdata"
+            ports:
+            -  containerPort: 5432
+            resources:
+{{- toYaml .Values.database.resources | nindent 14 }}
+            volumeMounts:
+            - name: {{ .Values.name }}-pg-pv-main
+              mountPath: /var/lib/postgresql/data
+        {{- end }}
+        {{- if .Values.redis.enabled }}
+         -  name: {{ .Values.name }}-redis-container
+            image: redis:alpine
+            imagePullPolicy: Always
+            ports:
+            -  containerPort: 6379
+            resources:
+{{- toYaml .Values.redis.resources | nindent 14 }}
+            volumeMounts:
+            - name: {{ .Values.name }}-redis-main
+              mountPath: /home/data
+        {{- end }}
+
+         volumes:
+        {{- if .Values.database.enabled }}
+         - name: {{ .Values.name }}-pg-pv-main
+           persistentVolumeClaim:
+             claimName: {{ .Values.name }}-pg-pv-main
+        {{- end }}
+        {{- if .Values.redis.enabled }}
+         - name: {{ .Values.name }}-redis-main
+           persistentVolumeClaim:
+             claimName: {{ .Values.name }}-redis-main
+        {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -14,7 +14,6 @@ image:
 
 # Service configuration
 service:
-  type: ClusterIP
   port: 3000
   targetPort: 3000
 
@@ -22,15 +21,41 @@ service:
 nodeSelector:
   kubernetes.io/hostname: cluster-utc-node-07efe5
 
-# Environment variables consumed by the application
+# Database configuration
+database:
+  enabled: true
+  host: localhost
+  port: "5432"
+  user: verana
+  password: verana
+  db: verana_resolver
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  storage:
+    size: 10Gi
+    storageClassName: csi-cinder-classic
+
+# Redis configuration
+redis:
+  enabled: true
+  host: localhost
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
+# Application environment variables (non-infrastructure)
 env:
-  POSTGRES_HOST: "localhost"
-  POSTGRES_PORT: "5432"
-  POSTGRES_USER: "verana"
-  POSTGRES_PASSWORD: "verana"
-  POSTGRES_DB: "verana_resolver"
-  REDIS_URL: "redis://localhost:6379"
   INDEXER_API: "http://localhost:1317"
+  ECS_ECOSYSTEM_DIDS: ""
   PORT: "3000"
   LOG_LEVEL: "info"
   INSTANCE_ROLE: "leader"
@@ -38,9 +63,8 @@ env:
   CACHE_TTL: "86400"
   TRUST_TTL: "3600"
   POLL_OBJECT_CACHING_RETRY_DAYS: "7"
-  ECS_ECOSYSTEM_DIDS: ""
 
-# Additional env variables if needed (list of {name, value})
+# Extra environment variables (list of {name, value})
 extraEnv: []
 
 # Resource requests/limits for the resolver container
@@ -52,9 +76,8 @@ resources:
     memory: "1Gi"
     cpu: "500m"
 
-# Optional ingress configuration
+# Ingress configuration
 ingress:
-  enabled: true
   host: "{{ .Values.host }}.{{ .Values.global.domain }}"
   tlsSecret: public.{{ .Values.host }}.{{ .Values.global.domain }}-cert
   public:


### PR DESCRIPTION
## Summary\n\nFixes missing Helm chart dependencies per #55, aligned with the [verana-indexer reference](https://github.com/verana-labs/verana-indexer/blob/main/charts/templates/deployment.yaml).\n\n### Changes\n\n**`charts/templates/deployment.yaml`** — full rewrite:\n- **Deployment → StatefulSet** for stable identity and persistent storage\n- **PostgreSQL sidecar** container (`postgres:14-alpine`) with PVC, gated by `database.enabled`\n- **Redis sidecar** container (`redis:alpine`) with PVC, gated by `redis.enabled`\n- **Service** exposes db (5432) and redis (6379) ports when sidecars are enabled\n- **Env var wiring** — `POSTGRES_*` derived from `database.*`, `REDIS_URL` from `redis.host`\n- **Namespace** added to all resource metadata\n- **Ingress** always rendered (was gated by `ingress.enabled`)\n- **PVCs** with `helm.sh/resource-policy: keep` annotation\n\n**`charts/values.yaml`** — restructured:\n- Replaced flat `env.POSTGRES_*`/`env.REDIS_URL` with structured `database.*` and `redis.*` sections\n- Added `database.resources`, `database.storage`, `redis.resources`\n- Removed `service.type` (not needed for StatefulSet headless service)\n- Kept app-level env vars (`INDEXER_API`, `ECS_ECOSYSTEM_DIDS`, etc.) under `env`\n\n**`charts/README.md`** — updated documentation:\n- Documented all new configuration sections (Database, Redis, Resources, Ingress)\n- Added examples for sidecar-enabled and external-db deployments\n\n### Verified\n\n- `helm template ./charts` renders cleanly (sidecars enabled)\n- `helm template ./charts --set database.enabled=false --set redis.enabled=false` renders cleanly (external mode)\n\nCloses #55