### PR TITLE
fix: filter VS-REQ credentials by ECS_ECOSYSTEM_DIDS allowlist

### DIFF
--- a/src/polling/pass2.ts
+++ b/src/polling/pass2.ts
@@ -11,11 +11,12 @@ export async function runPass2(
   indexer: IndexerClient,
   currentBlock: number,
   cacheTtlSeconds: number,
+  allowedEcosystemDids: Set<string>,
 ): Promise<{ succeeded: string[]; failed: string[] }> {
   const succeeded: string[] = [];
   const failed: string[] = [];
 
-  const ctx = createEvaluationContext(currentBlock, cacheTtlSeconds);
+  const ctx = createEvaluationContext(currentBlock, cacheTtlSeconds, allowedEcosystemDids);
 
   for (const did of affectedDids) {
     try {

--- a/src/trust/resolve-trust.ts
+++ b/src/trust/resolve-trust.ts
@@ -105,6 +105,7 @@ export async function resolveTrust(
     indexer,
     ctx,
     resolveTrust,
+    ctx.allowedEcosystemDids,
   );
 
   // 8. Derive production flag
@@ -129,12 +130,14 @@ export async function resolveTrust(
 export function createEvaluationContext(
   currentBlock: number,
   cacheTtlSeconds: number,
+  allowedEcosystemDids: Set<string>,
 ): EvaluationContext {
   return {
     visitedDids: new Set<string>(),
     currentBlock,
     cacheTtlSeconds,
     trustMemo: new Map<string, TrustResult>(),
+    allowedEcosystemDids,
   };
 }
 

--- a/src/trust/types.ts
+++ b/src/trust/types.ts
@@ -70,4 +70,5 @@ export interface EvaluationContext {
   currentBlock: number;
   cacheTtlSeconds: number;
   trustMemo: Map<string, TrustResult>;
+  allowedEcosystemDids: Set<string>;
 }

--- a/src/trust/vs-requirements.ts
+++ b/src/trust/vs-requirements.ts
@@ -15,12 +15,14 @@ export async function evaluateVSRequirements(
   indexer: IndexerClient,
   ctx: EvaluationContext,
   resolveTrustFn: (did: string, indexer: IndexerClient, ctx: EvaluationContext) => Promise<TrustResult>,
+  allowedEcosystemDids: Set<string>,
 ): Promise<TrustStatus> {
-  // Group valid credentials by ecosystem
+  // Group valid credentials by ecosystem, filtering out ecosystems not in the allowlist
   const byEcosystem = new Map<string, CredentialEvaluation[]>();
   for (const cred of validCredentials) {
     const ecosystemDid = cred.schema?.ecosystemDid;
     if (!ecosystemDid) continue;
+    if (!allowedEcosystemDids.has(ecosystemDid)) continue;
 
     const existing = byEcosystem.get(ecosystemDid) ?? [];
     existing.push(cred);

--- a/test/polling-loop.test.ts
+++ b/test/polling-loop.test.ts
@@ -216,6 +216,7 @@ describe('pollOnce', () => {
       currentBlock: 100,
       cacheTtlSeconds: 3600,
       trustMemo: new Map(),
+      allowedEcosystemDids: new Set(),
     }),
   }));
 
@@ -270,6 +271,7 @@ describe('pollOnce', () => {
       POLL_INTERVAL: 5,
       TRUST_TTL: 3600,
       POLL_OBJECT_CACHING_RETRY_DAYS: 7,
+      ECS_ECOSYSTEM_DIDS: 'did:web:ecosystem.example.com',
     } as any;
 
     const result = await pollOnce(mockIndexer, config);
@@ -297,6 +299,7 @@ describe('pollOnce', () => {
       POLL_INTERVAL: 5,
       TRUST_TTL: 3600,
       POLL_OBJECT_CACHING_RETRY_DAYS: 7,
+      ECS_ECOSYSTEM_DIDS: 'did:web:ecosystem.example.com',
     } as any;
 
     const result = await pollOnce(mockIndexer, config);

--- a/test/retry-subsystem.test.ts
+++ b/test/retry-subsystem.test.ts
@@ -62,6 +62,7 @@ vi.mock('../src/trust/resolve-trust.js', () => ({
     currentBlock: 100,
     cacheTtlSeconds: 3600,
     trustMemo: new Map(),
+    allowedEcosystemDids: new Set(),
   }),
 }));
 
@@ -199,6 +200,7 @@ describe('Pass2 \u2014 error handling', () => {
       {} as any,
       500,
       3600,
+      new Set(),
     );
 
     expect(result.failed).toContain('did:web:evalfail.example.com');

--- a/test/trust-resolve.test.ts
+++ b/test/trust-resolve.test.ts
@@ -42,11 +42,13 @@ describe('classifyEcsType', () => {
 
 describe('createEvaluationContext', () => {
   it('creates a context with empty visited set and memo', () => {
-    const ctx = createEvaluationContext(1500000, 3600);
+    const allowed = new Set(['did:web:ecosystem.example.com']);
+    const ctx = createEvaluationContext(1500000, 3600, allowed);
     expect(ctx.currentBlock).toBe(1500000);
     expect(ctx.cacheTtlSeconds).toBe(3600);
     expect(ctx.visitedDids.size).toBe(0);
     expect(ctx.trustMemo.size).toBe(0);
+    expect(ctx.allowedEcosystemDids).toBe(allowed);
   });
 });
 
@@ -88,25 +90,31 @@ function makeTrustResult(did: string, creds: CredentialEvaluation[]): TrustResul
 
 const mockIndexer = {} as IndexerClient;
 
+const defaultAllowedEcosystems = new Set([
+  'did:web:ecosystem.example.com',
+  'did:web:eco1.example.com',
+  'did:web:eco2.example.com',
+]);
+
 describe('evaluateVSRequirements', () => {
   it('returns UNTRUSTED when no valid credentials', async () => {
-    const ctx = createEvaluationContext(1500000, 3600);
+    const ctx = createEvaluationContext(1500000, 3600, defaultAllowedEcosystems);
     const mockResolve = vi.fn();
-    const result = await evaluateVSRequirements('did:web:test.example.com', [], mockIndexer, ctx, mockResolve);
+    const result = await evaluateVSRequirements('did:web:test.example.com', [], mockIndexer, ctx, mockResolve, defaultAllowedEcosystems);
     expect(result).toBe('UNTRUSTED');
   });
 
   it('returns UNTRUSTED when credentials have no ecosystem', async () => {
-    const ctx = createEvaluationContext(1500000, 3600);
+    const ctx = createEvaluationContext(1500000, 3600, defaultAllowedEcosystems);
     const mockResolve = vi.fn();
     const cred = makeCred({ ecsType: 'ECS-SERVICE', schema: undefined });
-    const result = await evaluateVSRequirements('did:web:test.example.com', [cred], mockIndexer, ctx, mockResolve);
+    const result = await evaluateVSRequirements('did:web:test.example.com', [cred], mockIndexer, ctx, mockResolve, defaultAllowedEcosystems);
     expect(result).toBe('UNTRUSTED');
   });
 
   it('returns TRUSTED for VS-REQ-3: self-issued service + org (same DID)', async () => {
     const did = 'did:web:acme.example.com';
-    const ctx = createEvaluationContext(1500000, 3600);
+    const ctx = createEvaluationContext(1500000, 3600, defaultAllowedEcosystems);
     const mockResolve = vi.fn();
 
     const serviceCred = makeCred({
@@ -126,14 +134,14 @@ describe('evaluateVSRequirements', () => {
       },
     });
 
-    const result = await evaluateVSRequirements(did, [serviceCred, orgCred], mockIndexer, ctx, mockResolve);
+    const result = await evaluateVSRequirements(did, [serviceCred, orgCred], mockIndexer, ctx, mockResolve, defaultAllowedEcosystems);
     expect(result).toBe('TRUSTED');
     expect(mockResolve).not.toHaveBeenCalled();
   });
 
   it('returns UNTRUSTED for VS-REQ-3: self-issued service but no org/persona', async () => {
     const did = 'did:web:acme.example.com';
-    const ctx = createEvaluationContext(1500000, 3600);
+    const ctx = createEvaluationContext(1500000, 3600, defaultAllowedEcosystems);
     const mockResolve = vi.fn();
 
     const serviceCred = makeCred({
@@ -142,14 +150,14 @@ describe('evaluateVSRequirements', () => {
       issuedBy: did,
     });
 
-    const result = await evaluateVSRequirements(did, [serviceCred], mockIndexer, ctx, mockResolve);
+    const result = await evaluateVSRequirements(did, [serviceCred], mockIndexer, ctx, mockResolve, defaultAllowedEcosystems);
     expect(result).toBe('UNTRUSTED');
   });
 
   it('returns TRUSTED for VS-REQ-4: externally issued service + issuer has org', async () => {
     const did = 'did:web:alice.example.com';
     const issuerDid = 'did:web:certify.example.com';
-    const ctx = createEvaluationContext(1500000, 3600);
+    const ctx = createEvaluationContext(1500000, 3600, defaultAllowedEcosystems);
 
     const serviceCred = makeCred({
       ecsType: 'ECS-SERVICE',
@@ -166,7 +174,7 @@ describe('evaluateVSRequirements', () => {
 
     const mockResolve = vi.fn().mockResolvedValue(makeTrustResult(issuerDid, [issuerOrgCred]));
 
-    const result = await evaluateVSRequirements(did, [serviceCred], mockIndexer, ctx, mockResolve);
+    const result = await evaluateVSRequirements(did, [serviceCred], mockIndexer, ctx, mockResolve, defaultAllowedEcosystems);
     expect(result).toBe('TRUSTED');
     expect(mockResolve).toHaveBeenCalledWith(issuerDid, mockIndexer, ctx);
   });
@@ -174,7 +182,7 @@ describe('evaluateVSRequirements', () => {
   it('returns UNTRUSTED for VS-REQ-4: externally issued service but issuer has no org', async () => {
     const did = 'did:web:alice.example.com';
     const issuerDid = 'did:web:certify.example.com';
-    const ctx = createEvaluationContext(1500000, 3600);
+    const ctx = createEvaluationContext(1500000, 3600, defaultAllowedEcosystems);
 
     const serviceCred = makeCred({
       ecsType: 'ECS-SERVICE',
@@ -184,13 +192,13 @@ describe('evaluateVSRequirements', () => {
 
     const mockResolve = vi.fn().mockResolvedValue(makeTrustResult(issuerDid, []));
 
-    const result = await evaluateVSRequirements(did, [serviceCred], mockIndexer, ctx, mockResolve);
+    const result = await evaluateVSRequirements(did, [serviceCred], mockIndexer, ctx, mockResolve, defaultAllowedEcosystems);
     expect(result).toBe('UNTRUSTED');
   });
 
   it('returns PARTIAL when some ecosystems satisfied, others not', async () => {
     const did = 'did:web:acme.example.com';
-    const ctx = createEvaluationContext(1500000, 3600);
+    const ctx = createEvaluationContext(1500000, 3600, defaultAllowedEcosystems);
     const mockResolve = vi.fn();
 
     // Ecosystem 1: satisfied (self-issued service + org)
@@ -236,8 +244,85 @@ describe('evaluateVSRequirements', () => {
       mockIndexer,
       ctx,
       mockResolve,
+      defaultAllowedEcosystems,
     );
     expect(result).toBe('PARTIAL');
+  });
+
+  it('returns UNTRUSTED when ecosystem DID is not in the allowlist', async () => {
+    const did = 'did:web:acme.example.com';
+    const disallowedEcosystems = new Set(['did:web:other-ecosystem.example.com']);
+    const ctx = createEvaluationContext(1500000, 3600, disallowedEcosystems);
+    const mockResolve = vi.fn();
+
+    const serviceCred = makeCred({
+      ecsType: 'ECS-SERVICE',
+      presentedBy: did,
+      issuedBy: did,
+    });
+    const orgCred = makeCred({
+      ecsType: 'ECS-ORG',
+      presentedBy: did,
+      issuedBy: 'did:web:ca-doi.example.com',
+    });
+
+    const result = await evaluateVSRequirements(did, [serviceCred, orgCred], mockIndexer, ctx, mockResolve, disallowedEcosystems);
+    expect(result).toBe('UNTRUSTED');
+  });
+
+  it('only considers credentials from allowed ecosystems', async () => {
+    const did = 'did:web:acme.example.com';
+    const partialAllow = new Set(['did:web:eco1.example.com']);
+    const ctx = createEvaluationContext(1500000, 3600, partialAllow);
+    const mockResolve = vi.fn();
+
+    // Ecosystem 1 (allowed): satisfied
+    const serviceCred1 = makeCred({
+      ecsType: 'ECS-SERVICE',
+      presentedBy: did,
+      issuedBy: did,
+      schema: {
+        id: 1,
+        jsonSchema: 'https://example.com/schemas/ecs-service/v1',
+        ecosystemDid: 'did:web:eco1.example.com',
+        issuerPermManagementMode: 'OPEN',
+      },
+    });
+    const orgCred1 = makeCred({
+      ecsType: 'ECS-ORG',
+      presentedBy: did,
+      issuedBy: 'did:web:issuer.example.com',
+      schema: {
+        id: 2,
+        jsonSchema: 'https://example.com/schemas/ecs-org/v1',
+        ecosystemDid: 'did:web:eco1.example.com',
+        issuerPermManagementMode: 'OPEN',
+      },
+    });
+
+    // Ecosystem 2 (NOT allowed): would be unsatisfied, but filtered out
+    const serviceCred2 = makeCred({
+      ecsType: 'ECS-SERVICE',
+      presentedBy: did,
+      issuedBy: did,
+      schema: {
+        id: 3,
+        jsonSchema: 'https://another.example.com/schemas/ecs-service/v1',
+        ecosystemDid: 'did:web:eco2.example.com',
+        issuerPermManagementMode: 'OPEN',
+      },
+    });
+
+    // eco2 is NOT in allowlist, so only eco1 is evaluated → TRUSTED (not PARTIAL)
+    const result = await evaluateVSRequirements(
+      did,
+      [serviceCred1, orgCred1, serviceCred2],
+      mockIndexer,
+      ctx,
+      mockResolve,
+      partialAllow,
+    );
+    expect(result).toBe('TRUSTED');
   });
 });
 
@@ -245,14 +330,14 @@ describe('evaluateVSRequirements', () => {
 
 describe('EvaluationContext cycle detection', () => {
   it('visitedDids tracks seen DIDs', () => {
-    const ctx = createEvaluationContext(100, 3600);
+    const ctx = createEvaluationContext(100, 3600, defaultAllowedEcosystems);
     ctx.visitedDids.add('did:web:a.example.com');
     expect(ctx.visitedDids.has('did:web:a.example.com')).toBe(true);
     expect(ctx.visitedDids.has('did:web:b.example.com')).toBe(false);
   });
 
   it('trustMemo caches results', () => {
-    const ctx = createEvaluationContext(100, 3600);
+    const ctx = createEvaluationContext(100, 3600, defaultAllowedEcosystems);
     const result = makeTrustResult('did:web:a.example.com', []);
     ctx.trustMemo.set('did:web:a.example.com', result);
     expect(ctx.trustMemo.get('did:web:a.example.com')).toBe(result);


### PR DESCRIPTION
# Summary

ECS-SERVICE, ECS-PERSONA, and ECS-ORG credentials are now only trusted if their ecosystem DID is listed in `ECS_ECOSYSTEM_DIDS`. Credentials from unlisted ecosystems are silently excluded from VS-REQ-2/3/4 evaluation.

## Changes

### Core logic
- **`src/trust/vs-requirements.ts`** — `evaluateVSRequirements` now accepts `allowedEcosystemDids: Set<string>` and filters credentials whose `ecosystemDid` is not in the allowlist before grouping by ecosystem
- **`src/trust/types.ts`** — `EvaluationContext` extended with `allowedEcosystemDids`
- **`src/trust/resolve-trust.ts`** — `resolveTrust` passes `ctx.allowedEcosystemDids` to `evaluateVSRequirements`; `createEvaluationContext` accepts and stores `allowedEcosystemDids`

### Plumbing
- **`src/polling/pass2.ts`** — `runPass2` accepts `allowedEcosystemDids` parameter (removed internal `getConfig()` call for testability)
- **`src/polling/polling-loop.ts`** — Parses `ECS_ECOSYSTEM_DIDS` once per polling cycle and threads the set through `runPass2`, `retryEligiblePass2`, and `refreshExpiredEvaluations`

### Tests
- **`test/trust-resolve.test.ts`** — All existing tests updated for new signatures; 2 new tests added:
  - `returns UNTRUSTED when ecosystem DID is not in the allowlist`
  - `only considers credentials from allowed ecosystems` (verifies disallowed ecosystems are filtered, not counted as PARTIAL)
- **`test/polling-loop.test.ts`** — Mock config and `createEvaluationContext` updated with `allowedEcosystemDids`
- **`test/retry-subsystem.test.ts`** — Mock and `runPass2` call updated with `allowedEcosystemDids`

## Testing

- `tsc --noEmit` ✅
- `vitest run` — 130/130 tests pass ✅

Closes #62