### PR TITLE
feat: add docker-compose for local dev (PostgreSQL + Redis)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,39 @@
+# Docker Development Environment
+
+Runs PostgreSQL and Redis locally for the Verana Trust Resolver.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose
+
+## Quick Start
+
+```bash
+# Start services
+cd docker && docker compose up -d
+
+# Verify
+docker compose ps
+
+# View logs
+docker compose logs -f
+```
+
+## Connection Details
+
+| Service    | Host        | Port   | Credentials              |
+|------------|-------------|--------|--------------------------|
+| PostgreSQL | `localhost` | `5432` | `verana` / `verana`      |
+| Redis      | `localhost` | `6379` | —                        |
+
+These match the defaults in `.env.example` at the project root.
+
+## Stop & Cleanup
+
+```bash
+# Stop (preserves data)
+docker compose down
+
+# Stop and delete volumes
+docker compose down -v
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,42 @@
+# Verana Trust Resolver — Developer Dependencies
+#
+# Starts PostgreSQL and Redis for local development.
+# Usage:
+#   cd docker && docker compose up -d
+#   cd docker && docker compose down          # stop
+#   cd docker && docker compose down -v       # stop + delete volumes
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: verana
+      POSTGRES_PASSWORD: verana
+      POSTGRES_DB: verana_resolver
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U verana -d verana_resolver"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  pgdata:
+  redisdata:


### PR DESCRIPTION
## Summary

Adds a `docker/` directory with a `docker-compose.yml` for running the resolver's dependent services locally during development.

## Services

| Service    | Image              | Port   | Credentials         |
|------------|--------------------|--------|---------------------|
| PostgreSQL | `postgres:16-alpine` | `5432` | `verana` / `verana` |
| Redis      | `redis:7-alpine`     | `6379` | —                   |

- Named volumes for data persistence across restarts
- Health checks for both services
- Credentials match `.env.example` defaults — no extra config needed

## Usage

```bash
cd docker && docker compose up -d
```

See `docker/README.md` for full details.

Closes #68