### PR TITLE
feat: replace polling sleep with Indexer WebSocket block-processed notifications

### DIFF
--- a/src/polling/indexer-ws.ts
+++ b/src/polling/indexer-ws.ts
@@ -1,0 +1,157 @@
+import pino from 'pino';
+
+const logger = pino({ name: 'indexer-ws' });
+
+const MAX_BACKOFF_MS = 30_000;
+const INITIAL_BACKOFF_MS = 1_000;
+
+export interface BlockProcessedEvent {
+  type: 'block-processed';
+  height: number;
+  timestamp: string;
+}
+
+/**
+ * Derives the WebSocket URL from the Indexer HTTP API URL.
+ * http(s)://host:port/... → ws(s)://host:port/verana/indexer/v1/events
+ */
+export function deriveWsUrl(indexerApi: string): string {
+  const url = new URL(indexerApi);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = '/verana/indexer/v1/events';
+  return url.toString();
+}
+
+type BlockListener = (event: BlockProcessedEvent) => void;
+
+/**
+ * Persistent WebSocket connection to the Indexer events endpoint.
+ * Reconnects automatically with exponential backoff on failures.
+ */
+export class IndexerWebSocket {
+  private ws: WebSocket | null = null;
+  private wsUrl: string;
+  private listeners: Set<BlockListener> = new Set();
+  private backoff = INITIAL_BACKOFF_MS;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private closed = false;
+
+  constructor(indexerApi: string, private signal?: AbortSignal) {
+    this.wsUrl = deriveWsUrl(indexerApi);
+    this.signal?.addEventListener('abort', () => this.close(), { once: true });
+    this.connect();
+  }
+
+  onBlock(listener: BlockListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /**
+   * Returns a promise that resolves when a block-processed event arrives
+   * or after `timeoutMs` milliseconds, whichever comes first.
+   * Resolves `true` if a block event was received, `false` on timeout.
+   */
+  waitForBlock(timeoutMs: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      let settled = false;
+
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          cleanup();
+          resolve(false);
+        }
+      }, timeoutMs);
+
+      const cleanup = this.onBlock(() => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          resolve(true);
+        }
+      });
+
+      this.signal?.addEventListener('abort', () => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          cleanup();
+          resolve(false);
+        }
+      }, { once: true });
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.listeners.clear();
+  }
+
+  private connect(): void {
+    if (this.closed) return;
+
+    try {
+      this.ws = new WebSocket(this.wsUrl);
+    } catch {
+      this.scheduleReconnect();
+      return;
+    }
+
+    this.ws.onopen = () => {
+      logger.info({ url: this.wsUrl }, 'Connected to Indexer WebSocket');
+      this.backoff = INITIAL_BACKOFF_MS;
+    };
+
+    this.ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(String(event.data)) as Record<string, unknown>;
+        if (data.type === 'block-processed' && typeof data.height === 'number') {
+          const blockEvent: BlockProcessedEvent = {
+            type: 'block-processed',
+            height: data.height,
+            timestamp: String(data.timestamp ?? ''),
+          };
+          logger.debug({ height: blockEvent.height }, 'Block-processed event received');
+          for (const listener of this.listeners) {
+            listener(blockEvent);
+          }
+        }
+      } catch {
+        logger.warn('Failed to parse WebSocket message');
+      }
+    };
+
+    this.ws.onclose = () => {
+      if (!this.closed) {
+        logger.info('Indexer WebSocket closed \u2014 reconnecting');
+        this.scheduleReconnect();
+      }
+    };
+
+    this.ws.onerror = () => {
+      // onclose will fire after onerror, which triggers reconnect
+      logger.warn('Indexer WebSocket error');
+    };
+  }
+
+  private scheduleReconnect(): void {
+    if (this.closed) return;
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, this.backoff);
+
+    logger.info({ backoffMs: this.backoff }, 'Scheduling WebSocket reconnect');
+    this.backoff = Math.min(this.backoff * 2, MAX_BACKOFF_MS);
+  }
+}

--- a/test/indexer-ws.test.ts
+++ b/test/indexer-ws.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { deriveWsUrl, IndexerWebSocket } from '../src/polling/indexer-ws.js';
+
+// --- deriveWsUrl ---
+
+describe('deriveWsUrl', () => {
+  it('converts http to ws and appends events path', () => {
+    expect(deriveWsUrl('http://localhost:1317')).toBe('ws://localhost:1317/verana/indexer/v1/events');
+  });
+
+  it('converts https to wss and appends events path', () => {
+    expect(deriveWsUrl('https://idx.testnet.verana.network')).toBe(
+      'wss://idx.testnet.verana.network/verana/indexer/v1/events',
+    );
+  });
+
+  it('strips existing path and replaces with events path', () => {
+    expect(deriveWsUrl('http://localhost:1317/verana/indexer/v1')).toBe(
+      'ws://localhost:1317/verana/indexer/v1/events',
+    );
+  });
+
+  it('preserves port', () => {
+    const url = deriveWsUrl('http://127.0.0.1:3001');
+    expect(url).toBe('ws://127.0.0.1:3001/verana/indexer/v1/events');
+  });
+});
+
+// --- IndexerWebSocket ---
+
+// Mock the global WebSocket since we're in Node test env without a real server
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = 0;
+  closed = false;
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+    // Simulate async open
+    setTimeout(() => {
+      this.readyState = 1;
+      this.onopen?.();
+    }, 5);
+  }
+
+  close() {
+    this.closed = true;
+    this.readyState = 3;
+  }
+
+  // Test helper: simulate receiving a message
+  simulateMessage(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+
+  // Test helper: simulate close
+  simulateClose() {
+    this.onclose?.();
+  }
+}
+
+describe('IndexerWebSocket', () => {
+  let originalWebSocket: typeof globalThis.WebSocket;
+
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    originalWebSocket = globalThis.WebSocket;
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket;
+  });
+
+  it('connects to the derived WebSocket URL', () => {
+    const ws = new IndexerWebSocket('http://localhost:1317');
+    expect(MockWebSocket.instances.length).toBe(1);
+    expect(MockWebSocket.instances[0].url).toBe('ws://localhost:1317/verana/indexer/v1/events');
+    ws.close();
+  });
+
+  it('onBlock listener fires on block-processed message', async () => {
+    const ws = new IndexerWebSocket('http://localhost:1317');
+    const events: unknown[] = [];
+    ws.onBlock((e) => events.push(e));
+
+    // Wait for connection
+    await new Promise((r) => setTimeout(r, 10));
+
+    const mock = MockWebSocket.instances[0];
+    mock.simulateMessage({ type: 'block-processed', height: 42, timestamp: '2026-01-01T00:00:00Z' });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'block-processed',
+      height: 42,
+      timestamp: '2026-01-01T00:00:00Z',
+    });
+    ws.close();
+  });
+
+  it('ignores non-block-processed messages', async () => {
+    const ws = new IndexerWebSocket('http://localhost:1317');
+    const events: unknown[] = [];
+    ws.onBlock((e) => events.push(e));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const mock = MockWebSocket.instances[0];
+    mock.simulateMessage({ type: 'other-event', data: 'hello' });
+
+    expect(events).toHaveLength(0);
+    ws.close();
+  });
+
+  it('waitForBlock resolves true on block event', async () => {
+    const ws = new IndexerWebSocket('http://localhost:1317');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const mock = MockWebSocket.instances[0];
+
+    // Fire a block event after 20ms
+    setTimeout(() => {
+      mock.simulateMessage({ type: 'block-processed', height: 100, timestamp: '2026-01-01T00:00:00Z' });
+    }, 20);
+
+    const result = await ws.waitForBlock(5000);
+    expect(result).toBe(true);
+    ws.close();
+  });
+
+  it('waitForBlock resolves false on timeout', async () => {
+    const ws = new IndexerWebSocket('http://localhost:1317');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const result = await ws.waitForBlock(50);
+    expect(result).toBe(false);
+    ws.close();
+  });
+
+  it('waitForBlock resolves false on abort', async () => {
+    const ac = new AbortController();
+    const ws = new IndexerWebSocket('http://localhost:1317', ac.signal);
+    await new Promise((r) => setTimeout(r, 10));
+
+    setTimeout(() => ac.abort(), 20);
+
+    const result = await ws.waitForBlock(5000);
+    expect(result).toBe(false);
+    // ws is auto-closed by abort signal
+  });
+
+  it('unsubscribe removes listener', async () => {
+    const ws = new IndexerWebSocket('http://localhost:1317');
+    const events: unknown[] = [];
+    const unsub = ws.onBlock((e) => events.push(e));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    unsub();
+
+    const mock = MockWebSocket.instances[0];
+    mock.simulateMessage({ type: 'block-processed', height: 1, timestamp: '' });
+
+    expect(events).toHaveLength(0);
+    ws.close();
+  });
+
+  it('close() cleans up the WebSocket', () => {
+    const ws = new IndexerWebSocket('http://localhost:1317');
+    ws.close();
+    expect(MockWebSocket.instances[0].closed).toBe(true);
+  });
+
+  it('schedules reconnect on close', async () => {
+    vi.useFakeTimers();
+    const ws = new IndexerWebSocket('http://localhost:1317');
+
+    // Simulate the initial connection opening
+    await vi.advanceTimersByTimeAsync(10);
+    expect(MockWebSocket.instances.length).toBe(1);
+
+    // Simulate a close event
+    MockWebSocket.instances[0].simulateClose();
+
+    // Advance past the initial backoff (1000ms)
+    await vi.advanceTimersByTimeAsync(1100);
+
+    // Should have created a second WebSocket instance
+    expect(MockWebSocket.instances.length).toBe(2);
+
+    ws.close();
+    vi.useRealTimers();
+  });
+});

--- a/test/polling-loop.test.ts
+++ b/test/polling-loop.test.ts
@@ -169,6 +169,14 @@ describe('extractAffectedDids', () => {
 
 describe('pollOnce', () => {
   // Mock all dependencies
+  vi.mock('../src/polling/indexer-ws.js', () => ({
+    IndexerWebSocket: vi.fn().mockImplementation(() => ({
+      waitForBlock: vi.fn().mockResolvedValue(false),
+      onBlock: vi.fn().mockReturnValue(() => {}),
+      close: vi.fn(),
+    })),
+  }));
+
   vi.mock('../src/polling/leader.js', () => ({
     tryAcquireLeaderLock: vi.fn().mockResolvedValue(true),
     releaseLeaderLock: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary

Replaces the fixed `POLL_INTERVAL` sleep between polling cycles with real-time WebSocket notifications from the Indexer's `block-processed` event stream. Falls back to the timeout-based approach when the WebSocket is unavailable.

## Changes

### New: `src/polling/indexer-ws.ts`
- **`deriveWsUrl()`** — Converts `INDEXER_API` URL from `http(s)` to `ws(s)` and appends `/verana/indexer/v1/events`
- **`IndexerWebSocket`** class:
  - Connects to the Indexer events endpoint on construction
  - `onBlock(listener)` — Subscribe to `block-processed` events (returns unsubscribe fn)
  - `waitForBlock(timeoutMs)` — Promise that resolves `true` on block event, `false` on timeout
  - Auto-reconnects with exponential backoff (1s → 30s max) on disconnect/error
  - Cleans up on `AbortSignal` abort or explicit `close()`

### Updated: `src/polling/polling-loop.ts`
- `startPollingLoop` now creates an `IndexerWebSocket` and calls `ws.waitForBlock()` instead of `sleep()`
- WebSocket is closed in the `finally` block alongside leader lock release
- Removed unused `sleep()` function

### Tests: `test/indexer-ws.test.ts` (13 new tests)
- `deriveWsUrl` — http→ws, https→wss, port preservation, path replacement
- `IndexerWebSocket` — connection, onBlock listener, message filtering, waitForBlock (event/timeout/abort), unsubscribe, close cleanup, reconnect on disconnect

### Updated: `test/polling-loop.test.ts`
- Added `indexer-ws` mock so existing `pollOnce` tests continue to pass

## Design decisions
- **No new dependencies** — Uses Node.js 22 native `WebSocket` API (per `engines: >=22.0.0`)
- **Graceful degradation** — If WebSocket fails to connect, `waitForBlock` simply times out after `POLL_INTERVAL` seconds and the loop continues normally
- **`POLL_INTERVAL` retained** as the fallback timeout, not removed from config

## Verification
- `tsc --noEmit` ✅
- `vitest run` — 143/143 tests pass ✅

Closes #67