### PR TITLE
fix: add dotenv to load .env file into process.env

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@credo-ts/webvh": "^0.6.2",
     "@fastify/cors": "^11.0.0",
     "canonicalize": "^2.0.0",
+    "dotenv": "^17.3.1",
     "fastify": "^5.2.1",
     "ioredis": "^5.4.2",
     "jose": "^6.1.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import Fastify from 'fastify';
 import { loadConfig } from './config/index.js';
 import { registerQ1Route } from './routes/q1-resolve.js';


### PR DESCRIPTION
## Problem

`dotenv` was not installed and `.env` was never loaded into `process.env`, so all environment variables were `undefined` when running locally with a `.env` file.

## Fix

- Added `dotenv` (`^17.3.1`) as a dependency
- Added `import 'dotenv/config'` as the **first import** in `src/index.ts` — this loads `.env` into `process.env` before `loadConfig()` reads it

This is the standard ESM approach — `import 'dotenv/config'` is a side-effect import that calls `dotenv.config()` automatically.

## Verification

- `tsc --noEmit` ✅
- `vitest run` — 143/143 tests pass ✅

Closes #73