### PR TITLE
fix: register DrizzleStorageModule to provide Credo StorageService

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,16 +17,19 @@
     "format:check": "prettier --check 'src/**/*.ts' 'test/**/*.ts'",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "migrate:credo": "npx @credo-ts/drizzle-storage --bundle core migrate --dialect postgres --database-url \"$DRIZZLE_DATABASE_URL\""
   },
   "dependencies": {
     "@credo-ts/anoncreds": "^0.6.2",
     "@credo-ts/core": "^0.6.2",
+    "@credo-ts/drizzle-storage": "^0.6.2",
     "@credo-ts/node": "^0.6.2",
     "@credo-ts/webvh": "^0.6.2",
     "@fastify/cors": "^11.0.0",
     "canonicalize": "^2.0.0",
     "dotenv": "^17.3.1",
+    "drizzle-orm": "^0.44.7",
     "fastify": "^5.2.1",
     "ioredis": "^5.4.2",
     "jose": "^6.1.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,9 @@ async function main(): Promise<void> {
   const config = loadConfig();
 
   // 1. Initialize Credo SSI agent (did:web, did:webvh, W3C VC verification)
+  const postgresUrl = `postgresql://${config.POSTGRES_USER}:${config.POSTGRES_PASSWORD}@${config.POSTGRES_HOST}:${config.POSTGRES_PORT}/${config.POSTGRES_DB}`;
   logger.info('Initializing SSI agent...');
-  await initializeAgent();
+  await initializeAgent(postgresUrl);
 
   // 2. Connect to PostgreSQL and run pending migrations
   logger.info('Connecting to PostgreSQL and running migrations...');

--- a/src/ssi/agent.ts
+++ b/src/ssi/agent.ts
@@ -1,15 +1,24 @@
 import { Agent, DidsModule, WebDidResolver, W3cCredentialsModule } from '@credo-ts/core';
 import { agentDependencies } from '@credo-ts/node';
 import { WebVhModule } from '@credo-ts/webvh';
+import { DrizzleStorageModule } from '@credo-ts/drizzle-storage';
+import { coreBundle } from '@credo-ts/drizzle-storage/core';
+import { drizzle } from 'drizzle-orm/node-postgres';
 
 let _agent: Agent | null = null;
 
-export async function initializeAgent(): Promise<Agent> {
+export async function initializeAgent(postgresUrl: string): Promise<Agent> {
   if (_agent !== null) return _agent;
+
+  const database = drizzle(postgresUrl);
 
   const agent = new Agent({
     dependencies: agentDependencies,
     modules: {
+      drizzleStorage: new DrizzleStorageModule({
+        database,
+        bundles: [coreBundle],
+      }),
       dids: new DidsModule({
         resolvers: [new WebDidResolver()],
       }),


### PR DESCRIPTION
## Problem

The Credo `Agent` fails to initialize at startup:

```
CredoError: Missing required dependency: 'StorageService'. 
You can register it using the AskarModule, DrizzleStorageModule, or implement your own.
```

## Solution

Register `@credo-ts/drizzle-storage` (pure JS/TS, no native deps) with our existing PostgreSQL database.

### Changes

- **`package.json`** — Added `@credo-ts/drizzle-storage` (^0.6.2) and `drizzle-orm` (^0.44.7). Added `migrate:credo` npm script for running Credo's Drizzle migrations.
- **`src/ssi/agent.ts`** — Import `DrizzleStorageModule` + `coreBundle`, create a Drizzle database instance from the PostgreSQL URL, register it in the Agent modules.  `initializeAgent()` now accepts a `postgresUrl` parameter.
- **`src/index.ts`** — Build PostgreSQL URL from config and pass to `initializeAgent(postgresUrl)`.

### Why DrizzleStorageModule over AskarModule

`@credo-ts/askar` requires the native binary `@openwallet-foundation/askar-nodejs`. Its transitive dependency `@2060.io/ref-napi` has no prebuilt for Node 23 / Darwin ARM64 and fails to compile from source. `DrizzleStorageModule` is pure JS/TS, reuses our existing PostgreSQL, and has zero native dependencies.

### Migration setup

Before first run, Credo's Drizzle tables must be created:

```bash
DRIZZLE_DATABASE_URL=\"postgresql://verana:verana@localhost:5432/verana_resolver\" npm run migrate:credo
```

## Verification

- `tsc --noEmit` ✅
- `vitest run` — 143/143 tests pass ✅

Closes #75