### PR TITLE
fix: remove NOW() from partial index predicate in initial schema

### DIFF
--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -8,8 +8,7 @@ CREATE TABLE trust_results (
   expires_at      TIMESTAMPTZ NOT NULL
 );
 
-CREATE INDEX idx_trust_expires ON trust_results(expires_at)
-  WHERE expires_at <= NOW();
+CREATE INDEX idx_trust_expires ON trust_results(expires_at);
 
 -- Per-credential evaluation results, linked to the DID
 CREATE TABLE credential_results (


### PR DESCRIPTION
## Problem

`001_initial_schema.sql` uses `NOW()` in a partial index predicate:

```sql
CREATE INDEX idx_trust_expires ON trust_results(expires_at)
  WHERE expires_at <= NOW();
```

PostgreSQL requires `IMMUTABLE` functions in partial index predicates. `NOW()` is `STABLE`, causing the migration to fail:

```
error: functions in index predicate must be marked IMMUTABLE
```

Additionally, this partial index is semantically wrong — `NOW()` is evaluated once at index creation time, not dynamically. It would create a fixed subset of rows rather than a rolling window.

## Fix

Replace with a plain B-tree index:

```sql
CREATE INDEX idx_trust_expires ON trust_results(expires_at);
```

Runtime queries (`WHERE expires_at <= NOW()` / `WHERE expires_at > NOW()`) use `NOW()` at query time and PostgreSQL uses the B-tree index for range scans.

## Verification

- `tsc --noEmit` ✅
- `vitest run` — 143/143 tests pass ✅

Closes #77