### PR TITLE
feat: add verbose debug/info logging to pass1, pass2, and trust evaluation

### DIFF
--- a/src/polling/pass2.ts
+++ b/src/polling/pass2.ts
@@ -16,12 +16,19 @@ export async function runPass2(
   const succeeded: string[] = [];
   const failed: string[] = [];
 
+  logger.info({ didCount: affectedDids.size, block: currentBlock }, 'Pass2 started \u2014 trust evaluation');
+
   const ctx = createEvaluationContext(currentBlock, cacheTtlSeconds, allowedEcosystemDids);
 
   for (const did of affectedDids) {
     try {
+      logger.debug({ did }, 'Pass2: evaluating trust');
       const result = await resolveTrust(did, indexer, ctx);
       await upsertTrustResult(result);
+      logger.info(
+        { did, trustStatus: result.trustStatus, production: result.production, validCredentials: result.credentials.filter((c) => c.result === 'VALID').length, failedCredentials: result.failedCredentials.length },
+        'Pass2: DID trust evaluated and stored',
+      );
       succeeded.push(did);
     } catch (err) {
       logger.error({ did, err }, 'Pass2: trust evaluation failed');
@@ -30,5 +37,6 @@ export async function runPass2(
     }
   }
 
+  logger.info({ succeeded: succeeded.length, failed: failed.length, block: currentBlock }, 'Pass2 complete');
   return { succeeded, failed };
 }

--- a/src/ssi/did-resolver.ts
+++ b/src/ssi/did-resolver.ts
@@ -1,6 +1,9 @@
 import { getAgent } from './agent.js';
 import { getCachedFile, setCachedFile } from '../cache/file-cache.js';
 import type { ResolvedDIDDocument, DereferenceError } from './types.js';
+import pino from 'pino';
+
+const logger = pino({ name: 'did-resolver' });
 
 export async function resolveDID(did: string): Promise<{
   result?: ResolvedDIDDocument;
@@ -16,35 +19,47 @@ export async function resolveDID(did: string): Promise<{
       if (parsed.validUntil) {
         const validUntilDate = new Date(parsed.validUntil);
         if (validUntilDate.getTime() < Date.now()) {
-          // Expired — fall through to re-resolve
+          logger.debug({ did, validUntil: parsed.validUntil }, 'DID cache expired \u2014 re-resolving');
+          // Expired \u2014 fall through to re-resolve
         } else {
+          logger.debug({ did, validUntil: parsed.validUntil }, 'DID cache hit (valid)');
           return { result: parsed };
         }
       } else {
+        logger.debug({ did }, 'DID cache hit (no expiry)');
         return { result: parsed };
       }
     } catch {
-      // Invalid cache entry — re-resolve
+      logger.debug({ did }, 'DID cache entry invalid \u2014 re-resolving');
+      // Invalid cache entry \u2014 re-resolve
     }
+  } else {
+    logger.debug({ did }, 'DID cache miss');
   }
 
   // Resolve via Credo agent
+  logger.debug({ did }, 'Resolving DID via Credo agent');
   try {
     const agent = getAgent();
     const resolution = await agent.dids.resolve(did);
 
     if (resolution.didResolutionMetadata.error || !resolution.didDocument) {
+      const error = resolution.didResolutionMetadata.error ?? 'DID Document not found';
+      logger.debug({ did, error }, 'DID resolution failed');
       return {
         error: {
           resource: did,
           resourceType: 'did-document',
-          error: resolution.didResolutionMetadata.error ?? 'DID Document not found',
+          error,
           timestamp: Date.now(),
         },
       };
     }
 
     const didDocJson = resolution.didDocument.toJSON();
+    const serviceCount = Array.isArray((didDocJson as Record<string, unknown>).service)
+      ? ((didDocJson as Record<string, unknown>).service as unknown[]).length
+      : 0;
     const resolved: ResolvedDIDDocument = {
       did,
       didDocument: didDocJson as Record<string, unknown>,
@@ -52,16 +67,20 @@ export async function resolveDID(did: string): Promise<{
       validUntil: (resolution.didDocumentMetadata?.nextUpdate as string) ?? undefined,
     };
 
+    logger.debug({ did, serviceCount, validUntil: resolved.validUntil ?? 'none' }, 'DID resolved successfully');
+
     // Cache in Redis
     await setCachedFile(did, JSON.stringify(resolved));
 
     return { result: resolved };
   } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    logger.debug({ did, error: errorMsg }, 'DID resolution threw an exception');
     return {
       error: {
         resource: did,
         resourceType: 'did-document',
-        error: err instanceof Error ? err.message : String(err),
+        error: errorMsg,
         timestamp: Date.now(),
       },
     };

--- a/src/trust/vs-requirements.ts
+++ b/src/trust/vs-requirements.ts
@@ -1,13 +1,16 @@
 import type { IndexerClient } from '../indexer/client.js';
 import type { CredentialEvaluation, EvaluationContext, TrustResult, TrustStatus } from './types.js';
+import pino from 'pino';
+
+const logger = pino({ name: 'vs-requirements' });
 
 /**
  * Evaluate VS-REQ-2/3/4 requirements.
  *
  * Groups valid credentials by ecosystem, then for each ecosystem:
  * - Checks for ECS-SERVICE presence (VS-REQ-2)
- * - VS-REQ-3: if self-issued service cred → VS must also present ECS-ORG or ECS-PERSONA
- * - VS-REQ-4: if externally issued service cred → issuer's DID must present ECS-ORG or ECS-PERSONA
+ * - VS-REQ-3: if self-issued service cred \u2192 VS must also present ECS-ORG or ECS-PERSONA
+ * - VS-REQ-4: if externally issued service cred \u2192 issuer's DID must present ECS-ORG or ECS-PERSONA
  */
 export async function evaluateVSRequirements(
   did: string,
@@ -17,39 +20,60 @@ export async function evaluateVSRequirements(
   resolveTrustFn: (did: string, indexer: IndexerClient, ctx: EvaluationContext) => Promise<TrustResult>,
   allowedEcosystemDids: Set<string>,
 ): Promise<TrustStatus> {
+  logger.debug({ did, validCredentials: validCredentials.length, allowedEcosystems: [...allowedEcosystemDids] }, 'Evaluating VS requirements');
+
   // Group valid credentials by ecosystem, filtering out ecosystems not in the allowlist
   const byEcosystem = new Map<string, CredentialEvaluation[]>();
   for (const cred of validCredentials) {
     const ecosystemDid = cred.schema?.ecosystemDid;
-    if (!ecosystemDid) continue;
-    if (!allowedEcosystemDids.has(ecosystemDid)) continue;
+    if (!ecosystemDid) {
+      logger.debug({ did, credId: cred.id, ecsType: cred.ecsType }, 'Credential has no ecosystem DID \u2014 skipped');
+      continue;
+    }
+    if (!allowedEcosystemDids.has(ecosystemDid)) {
+      logger.debug({ did, credId: cred.id, ecosystemDid }, 'Credential ecosystem not in allowlist \u2014 skipped');
+      continue;
+    }
 
     const existing = byEcosystem.get(ecosystemDid) ?? [];
     existing.push(cred);
     byEcosystem.set(ecosystemDid, existing);
   }
 
-  if (byEcosystem.size === 0) return 'UNTRUSTED';
+  logger.debug({ did, ecosystemCount: byEcosystem.size, ecosystems: [...byEcosystem.keys()] }, 'Credentials grouped by ecosystem');
+
+  if (byEcosystem.size === 0) {
+    logger.debug({ did }, 'No valid credentials in any allowed ecosystem \u2014 UNTRUSTED');
+    return 'UNTRUSTED';
+  }
 
   let satisfiedEcosystems = 0;
   const totalEcosystems = byEcosystem.size;
 
-  for (const [, creds] of byEcosystem) {
-    const serviceCred = creds.find((c) => c.ecsType === 'ECS-SERVICE');
-    if (!serviceCred) continue;
+  for (const [ecosystemDid, creds] of byEcosystem) {
+    const ecsTypes = creds.map((c) => c.ecsType);
+    logger.debug({ did, ecosystemDid, credCount: creds.length, ecsTypes }, 'Checking ecosystem');
 
-    // VS-REQ-3: self-issued → VS must also present ECS-ORG or ECS-PERSONA
+    const serviceCred = creds.find((c) => c.ecsType === 'ECS-SERVICE');
+    if (!serviceCred) {
+      logger.debug({ did, ecosystemDid }, 'VS-REQ-2: no ECS-SERVICE credential \u2014 ecosystem not satisfied');
+      continue;
+    }
+
+    // VS-REQ-3: self-issued \u2192 VS must also present ECS-ORG or ECS-PERSONA
     if (serviceCred.issuedBy === did) {
       const hasOrgOrPersona = creds.some(
         (c) =>
           (c.ecsType === 'ECS-ORG' || c.ecsType === 'ECS-PERSONA') &&
           c.presentedBy === did,
       );
+      logger.debug({ did, ecosystemDid, selfIssued: true, hasOrgOrPersona }, 'VS-REQ-3: self-issued ECS-SERVICE check');
       if (hasOrgOrPersona) satisfiedEcosystems++;
       continue;
     }
 
-    // VS-REQ-4: issued by another DID → issuer's DID must present ECS-ORG or ECS-PERSONA
+    // VS-REQ-4: issued by another DID \u2192 issuer's DID must present ECS-ORG or ECS-PERSONA
+    logger.debug({ did, ecosystemDid, issuerDid: serviceCred.issuedBy }, 'VS-REQ-4: resolving issuer trust');
     const issuerResult = await resolveTrustFn(serviceCred.issuedBy, indexer, ctx);
     const issuerHasOrgOrPersona = issuerResult.credentials.some(
       (c) =>
@@ -57,10 +81,15 @@ export async function evaluateVSRequirements(
         c.presentedBy === serviceCred.issuedBy &&
         c.result === 'VALID',
     );
+    logger.debug({ did, ecosystemDid, issuerDid: serviceCred.issuedBy, issuerHasOrgOrPersona, issuerTrustStatus: issuerResult.trustStatus }, 'VS-REQ-4: issuer trust resolved');
     if (issuerHasOrgOrPersona) satisfiedEcosystems++;
   }
 
-  if (satisfiedEcosystems === totalEcosystems && totalEcosystems > 0) return 'TRUSTED';
-  if (satisfiedEcosystems > 0) return 'PARTIAL';
-  return 'UNTRUSTED';
+  let status: TrustStatus;
+  if (satisfiedEcosystems === totalEcosystems && totalEcosystems > 0) status = 'TRUSTED';
+  else if (satisfiedEcosystems > 0) status = 'PARTIAL';
+  else status = 'UNTRUSTED';
+
+  logger.debug({ did, satisfiedEcosystems, totalEcosystems, status }, 'VS requirements evaluation complete');
+  return status;
 }


### PR DESCRIPTION
## Summary

Add structured pino logging throughout the trust resolution pipeline so operators can trace every step at `info` and `debug` levels. Controlled by `LOG_LEVEL` env var — set to `debug` for full step-by-step output.

## Files Changed (7)

| File | Logging Added |
|------|--------------|
| `src/polling/pass1.ts` | Start/end summary, per-DID cache invalidation, DID resolution outcome, VP dereference counts |
| `src/polling/pass2.ts` | Start/end summary, per-DID trust status + credential counts |
| `src/trust/resolve-trust.ts` | 5-step progress (DID doc → VPs → credentials → VS-REQ → result), memo hits, cycle detection |
| `src/trust/evaluate-credential.ts` | Signature verification, VTJSC→schema resolution, ECS classification, digest lookup, issuer permission check, final result |
| `src/trust/vs-requirements.ts` | Ecosystem grouping, VS-REQ-2/3/4 checks per ecosystem, satisfied/total summary |
| `src/ssi/did-resolver.ts` | Cache hit/miss/expired, Credo resolution result with service count |
| `src/ssi/vp-dereferencer.ts` | Cache hit/miss, fetch results, credential extraction counts, endpoint listing |

## Log Level Strategy

- **`logger.info`** — Key milestones: pass start/end, per-DID final trust status, DID resolution failures
- **`logger.debug`** — Step-by-step detail: cache states, individual VP/VC results, permission lookups, VS-REQ checks
- **`logger.warn`** — Existing warnings preserved (permanent failures, VP dereference errors, circular refs)

## Example Output (LOG_LEVEL=info)

```
Pass1 started — DID resolution + VP dereferencing  {didCount: 3, block: 42}
Pass1: DID processed OK  {did: "did:web:example.com", vpsOk: 2, vpsFailed: 0, credentials: 4}
Pass1 complete  {succeeded: 3, failed: 0, block: 42}
Pass2 started — trust evaluation  {didCount: 3, block: 42}
Trust evaluation started  {did: "did:web:example.com", block: 42}
Step 5/5: Trust evaluation complete  {did: "did:web:example.com", trustStatus: "TRUSTED", production: true, validCredentials: 3, failedCredentials: 0}
Pass2: DID trust evaluated and stored  {did: "did:web:example.com", trustStatus: "TRUSTED", production: true}
Pass2 complete  {succeeded: 3, failed: 0, block: 42}
```

## Verification

- `tsc --noEmit` ✅
- `vitest run` — 149/149 tests pass ✅
- No behavioural changes — logging only

Closes #89