### PR TITLE
fix: register WebVhDidResolver in Credo DidsModule

### DIFF
--- a/src/ssi/agent.ts
+++ b/src/ssi/agent.ts
@@ -1,6 +1,6 @@
 import { Agent, DidsModule, WebDidResolver, W3cCredentialsModule } from '@credo-ts/core';
 import { agentDependencies } from '@credo-ts/node';
-import { WebVhModule } from '@credo-ts/webvh';
+import { WebVhModule, WebVhDidResolver } from '@credo-ts/webvh';
 import { DrizzleStorageModule } from '@credo-ts/drizzle-storage';
 import { coreBundle } from '@credo-ts/drizzle-storage/core';
 import { drizzle } from 'drizzle-orm/node-postgres';
@@ -20,7 +20,7 @@ export async function initializeAgent(postgresUrl: string): Promise<Agent> {
         bundles: [coreBundle],
       }),
       dids: new DidsModule({
-        resolvers: [new WebDidResolver()],
+        resolvers: [new WebDidResolver(), new WebVhDidResolver()],
       }),
       w3cCredentials: new W3cCredentialsModule(),
       webVh: new WebVhModule(),


### PR DESCRIPTION
## Summary

`did:webvh` resolution was failing with `unsupportedDidMethod` because `WebVhDidResolver` was never added to the `DidsModule.resolvers` array. Only `WebDidResolver` (for `did:web`) was registered.

## Fix

One-line change in `src/ssi/agent.ts`:

```diff
-import { WebVhModule } from '@credo-ts/webvh';
+import { WebVhModule, WebVhDidResolver } from '@credo-ts/webvh';
 // ...
 dids: new DidsModule({
-  resolvers: [new WebDidResolver()],
+  resolvers: [new WebDidResolver(), new WebVhDidResolver()],
 }),
```

## Verification

- `tsc --noEmit` ✅
- `vitest run` — 149/149 tests pass ✅

Closes #91