### PR TITLE
fix: include human-readable message in DID resolution error logs

### DIFF
--- a/src/polling/pass1.ts
+++ b/src/polling/pass1.ts
@@ -74,13 +74,14 @@ export async function runPass1(
       logger.debug({ did }, 'Pass1: resolving DID document');
       const didResult = await resolveDID(did);
       if (didResult.error || !didResult.result) {
-        const errorMsg = didResult.error?.error;
-        if (isPermanentDIDError(errorMsg)) {
-          logger.warn({ did, error: errorMsg }, 'Pass1: permanent DID resolution failure \u2014 marking UNTRUSTED');
+        const errorCode = didResult.error?.error;
+        const errorMessage = didResult.error?.message;
+        if (isPermanentDIDError(errorCode)) {
+          logger.warn({ did, error: errorCode, message: errorMessage }, 'Pass1: permanent DID resolution failure \u2014 marking UNTRUSTED');
           await markUntrusted(did, currentBlock, trustTtlSeconds);
           await addReattemptable(did, 'DID_DOC', 'PERMANENT');
         } else {
-          logger.warn({ did, error: errorMsg }, 'Pass1: DID resolution failed (transient)');
+          logger.warn({ did, error: errorCode, message: errorMessage }, 'Pass1: DID resolution failed (transient)');
           await addReattemptable(did, 'DID_DOC', 'TRANSIENT');
         }
         failed.push(did);

--- a/src/ssi/did-resolver.ts
+++ b/src/ssi/did-resolver.ts
@@ -45,12 +45,14 @@ export async function resolveDID(did: string): Promise<{
 
     if (resolution.didResolutionMetadata.error || !resolution.didDocument) {
       const error = resolution.didResolutionMetadata.error ?? 'DID Document not found';
-      logger.debug({ did, error }, 'DID resolution failed');
+      const message = (resolution.didResolutionMetadata as Record<string, unknown>).message as string | undefined;
+      logger.debug({ did, error, message: message ?? 'none' }, 'DID resolution failed');
       return {
         error: {
           resource: did,
           resourceType: 'did-document',
           error,
+          message,
           timestamp: Date.now(),
         },
       };

--- a/src/ssi/types.ts
+++ b/src/ssi/types.ts
@@ -34,5 +34,6 @@ export interface DereferenceError {
   resource: string;
   resourceType: 'did-document' | 'vp' | 'vc';
   error: string;
+  message?: string;
   timestamp: number;
 }

--- a/src/trust/resolve-trust.ts
+++ b/src/trust/resolve-trust.ts
@@ -55,7 +55,8 @@ export async function resolveTrust(
   const didResult = await resolveDID(did);
   if (didResult.error || !didResult.result) {
     const error = didResult.error?.error ?? 'DID resolution failed';
-    logger.info({ did, error }, 'Trust evaluation \u2014 DID resolution failed \u2014 UNTRUSTED');
+    const message = didResult.error?.message;
+    logger.info({ did, error, message: message ?? 'none' }, 'Trust evaluation \u2014 DID resolution failed \u2014 UNTRUSTED');
     const unresolvedResult: TrustResult = {
       did,
       trustStatus: 'UNTRUSTED',
@@ -67,7 +68,7 @@ export async function resolveTrust(
       failedCredentials: [{
         id: did,
         format: 'N/A',
-        error,
+        error: message ? `${error}: ${message}` : error,
         errorCode: 'DID_RESOLUTION_FAILED',
       }],
     };


### PR DESCRIPTION
## Problem

DID resolution errors only show the error code (e.g. `"notFound"`) but not the human-readable cause from Credo's `didResolutionMetadata.message`. This makes it impossible to diagnose *why* a DID was not found.

**Before:**
```json
{"did":"did:webvh:Qm...","error":"notFound","msg":"Pass1: permanent DID resolution failure — marking UNTRUSTED"}
```

**After:**
```json
{"did":"did:webvh:Qm...","error":"notFound","message":"HTTP 404: Not Found at https://...","msg":"Pass1: permanent DID resolution failure — marking UNTRUSTED"}
```

## Changes (4 files)

| File | Change |
|------|--------|
| `src/ssi/types.ts` | Add `message?: string` to `DereferenceError` |
| `src/ssi/did-resolver.ts` | Extract `didResolutionMetadata.message` and include in returned error + debug log |
| `src/polling/pass1.ts` | Log `message` alongside error code at warn level |
| `src/trust/resolve-trust.ts` | Log `message` at info level; include `"error: message"` in `failedCredentials` error string |

## Verification

- `tsc --noEmit` ✅
- `vitest run` — 149/149 tests pass ✅

Closes #93