### PR TITLE
feat: switch DID resolution to DIF reference libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,27 +17,28 @@
     "format:check": "prettier --check 'src/**/*.ts' 'test/**/*.ts'",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
-    "migrate:credo": "npx @credo-ts/drizzle-storage --bundle core migrate --dialect postgres --database-url \"$DRIZZLE_DATABASE_URL\""
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@credo-ts/anoncreds": "^0.6.2",
+    "@credo-ts/askar": "^0.6.2",
     "@credo-ts/core": "^0.6.2",
-    "@credo-ts/drizzle-storage": "^0.6.2",
     "@credo-ts/node": "^0.6.2",
-    "@credo-ts/webvh": "^0.6.2",
     "@fastify/cors": "^11.0.0",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.5",
+    "@openwallet-foundation/askar-nodejs": "^0.6.0",
     "canonicalize": "^2.0.0",
+    "did-resolver": "^4.1.0",
+    "didwebvh-ts": "^2.7.1",
     "dotenv": "^17.3.1",
-    "drizzle-orm": "^0.44.7",
     "fastify": "^5.2.1",
     "ioredis": "^5.4.2",
     "jose": "^6.1.3",
     "pg": "^8.13.1",
     "pino": "^10.3.1",
     "prom-client": "^15.1.3",
+    "web-did-resolver": "^2.0.32",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,10 +22,9 @@ const logger = pino({ name: 'main' });
 async function main(): Promise<void> {
   const config = loadConfig();
 
-  // 1. Initialize Credo SSI agent (did:web, did:webvh, W3C VC verification)
-  const postgresUrl = `postgresql://${config.POSTGRES_USER}:${config.POSTGRES_PASSWORD}@${config.POSTGRES_HOST}:${config.POSTGRES_PORT}/${config.POSTGRES_DB}`;
+  // 1. Initialize Credo SSI agent (W3C VC verification only; DID resolution uses DIF libraries)
   logger.info('Initializing SSI agent...');
-  await initializeAgent(postgresUrl);
+  await initializeAgent();
 
   // 2. Connect to PostgreSQL and run pending migrations
   logger.info('Connecting to PostgreSQL and running migrations...');

--- a/src/ssi/agent.ts
+++ b/src/ssi/agent.ts
@@ -1,29 +1,26 @@
-import { Agent, DidsModule, WebDidResolver, W3cCredentialsModule } from '@credo-ts/core';
+import { askar, KdfMethod } from '@openwallet-foundation/askar-nodejs';
+import { AskarModule } from '@credo-ts/askar';
+import { Agent, W3cCredentialsModule } from '@credo-ts/core';
 import { agentDependencies } from '@credo-ts/node';
-import { WebVhModule, WebVhDidResolver } from '@credo-ts/webvh';
-import { DrizzleStorageModule } from '@credo-ts/drizzle-storage';
-import { coreBundle } from '@credo-ts/drizzle-storage/core';
-import { drizzle } from 'drizzle-orm/node-postgres';
 
 let _agent: Agent | null = null;
 
-export async function initializeAgent(postgresUrl: string): Promise<Agent> {
+export async function initializeAgent(): Promise<Agent> {
   if (_agent !== null) return _agent;
-
-  const database = drizzle(postgresUrl);
 
   const agent = new Agent({
     dependencies: agentDependencies,
     modules: {
-      drizzleStorage: new DrizzleStorageModule({
-        database,
-        bundles: [coreBundle],
-      }),
-      dids: new DidsModule({
-        resolvers: [new WebDidResolver(), new WebVhDidResolver()],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      askar: new AskarModule({
+        askar: askar as any,
+        store: {
+          id: `verana-resolver-${Date.now()}`,
+          key: 'verana-resolver-key',
+          keyDerivationMethod: KdfMethod.Raw as any,
+        },
       }),
       w3cCredentials: new W3cCredentialsModule(),
-      webVh: new WebVhModule(),
     },
   });
 


### PR DESCRIPTION
## Summary

Replace Credo's built-in DID resolvers with DIF (Decentralized Identity Foundation) reference implementations. Credo is kept only for W3C credential signature verification.

## Motivation

Credo's DID resolvers use strict `DidDocument` class validation (class-transformer) which fails with `ClassValidationError: Cannot validate instance of undefined` when DID documents contain service or verification method types not registered in Credo's discriminator map (e.g. `Multikey`, `relativeRef`, `did-communication`).

The DIF libraries return **plain JSON** — no class instantiation, no validation errors.

## New DID Resolution Architecture

| DID method | Library | Source |
|---|---|---|
| `did:web` | [`web-did-resolver`](https://github.com/decentralized-identity/web-did-resolver) v2.0.32 | DIF (98⭐) |
| `did:webvh` | [`didwebvh-ts`](https://github.com/decentralized-identity/didwebvh-ts) v2.7.1 | DIF reference impl |
| Framework | [`did-resolver`](https://github.com/decentralized-identity/did-resolver) v4.1.0 | DIF (229⭐) |
| Credential verification | Credo + `AskarModule` | OpenWallet Foundation |

## Changes

| File | Change |
|------|--------|
| `src/ssi/did-resolver.ts` | Route `did:web` → `web-did-resolver`, `did:webvh` → `didwebvh-ts`; remove Credo dependency |
| `src/ssi/agent.ts` | `AskarModule` + `W3cCredentialsModule` only; remove `DidsModule`, `WebVhModule`, resolvers |
| `src/index.ts` | `initializeAgent()` no longer needs `postgresUrl` |
| `package.json` | +`did-resolver`, `web-did-resolver`, `didwebvh-ts`, `@credo-ts/askar`, `askar-nodejs@0.6.0`; −`@credo-ts/drizzle-storage`, `@credo-ts/webvh`, `drizzle-orm`; −`migrate:credo` script |

## Verification

- `tsc --noEmit` ✅
- `vitest run` — 149/149 tests pass ✅
- `npm install` — no native compilation needed (askar-nodejs 0.6.0 uses koffi) ✅

Supersedes #92, #95. Closes #97.