### PR TITLE
feat: add verbose debug logging for VP/VC summaries and credential failure details

### DIFF
--- a/src/polling/pass1.ts
+++ b/src/polling/pass1.ts
@@ -105,6 +105,21 @@ export async function runPass1(
       }
 
       const totalCreds = vps.reduce((sum, vp) => sum + vp.credentials.length, 0);
+
+      // Per-VP/VC debug summary
+      for (const vp of vps) {
+        logger.debug(
+          { did, vpUrl: vp.vpUrl, credentials: vp.credentials.length },
+          'Pass1: VP dereferenced OK',
+        );
+        for (const cred of vp.credentials) {
+          logger.debug(
+            { did, vpUrl: vp.vpUrl, vcId: cred.vcId, format: cred.format, issuer: cred.issuerDid, schemaId: cred.credentialSchemaId ?? 'none' },
+            'Pass1: VC found',
+          );
+        }
+      }
+
       logger.info({ did, vpsOk: vps.length, vpsFailed: vpErrors.length, credentials: totalCreds }, 'Pass1: DID processed OK');
       succeeded.push(did);
     } catch (err) {

--- a/src/ssi/vp-dereferencer.ts
+++ b/src/ssi/vp-dereferencer.ts
@@ -76,6 +76,12 @@ export async function dereferenceVP(vpUrl: string): Promise<{
     const credentials = extractCredentialsFromVP(vpJson);
 
     logger.debug({ vpUrl, credentials: credentials.length }, 'VP fetched successfully');
+    for (const cred of credentials) {
+      logger.debug(
+        { vpUrl, vcId: cred.vcId, format: cred.format, issuer: cred.issuerDid, schemaId: cred.credentialSchemaId ?? 'none' },
+        'VP contains credential',
+      );
+    }
 
     const dereferenced: DereferencedVP = {
       vpUrl,
@@ -124,6 +130,20 @@ export async function dereferenceAllVPs(
 
   const totalCreds = vps.reduce((sum, vp) => sum + vp.credentials.length, 0);
   logger.debug({ vpsOk: vps.length, vpsFailed: errors.length, totalCredentials: totalCreds }, 'VP dereference complete');
+
+  // Per-VP summary
+  for (const vp of vps) {
+    logger.debug(
+      { vpUrl: vp.vpUrl, credentials: vp.credentials.length, vcIds: vp.credentials.map((c) => c.vcId) },
+      'VP summary: OK',
+    );
+  }
+  for (const err of errors) {
+    logger.debug(
+      { vpUrl: err.resource, error: err.error, message: err.message ?? 'none' },
+      'VP summary: FAILED',
+    );
+  }
 
   return { vps, errors };
 }


### PR DESCRIPTION
## Summary

Add comprehensive debug-level logging across the VP/VC dereferencing and trust evaluation pipeline, so that when `LOG_LEVEL=debug` is set, each step produces a clear summary of what was found and why things passed/failed.

## What's logged now (at debug level)

### Pass1 — VP dereferencing
- **Per-VP**: URL, credential count, list of VC IDs
- **Per-VC in VP**: vcId, format, issuer DID, schemaId
- **Failed VPs**: URL, error details

### Pass2 / resolve-trust — Trust evaluation
- **Per-credential result**:
  - `VALID`: ecsType, issuer, type, vtjscId, permission chain length
  - `IGNORED`: issuer, type, vtjscId (no ECS type match)
  - `FAILED`: errorCode, error message, format
- **UNTRUSTED summary**: all failure details as structured JSON array
- `ignoredCredentials` count now included in info-level logs

### evaluate-credential.ts
Already had detailed per-step logging (no changes needed).

## Files changed

| File | Change |
|------|--------|
| `src/ssi/vp-dereferencer.ts` | Per-credential detail on fetch, per-VP/failed-VP summary in `dereferenceAllVPs` |
| `src/polling/pass1.ts` | Per-VP/VC debug summary after VP dereferencing |
| `src/polling/pass2.ts` | Per-failed-credential detail when UNTRUSTED, `ignoredCredentials` in info log |
| `src/trust/resolve-trust.ts` | Per-credential VALID/IGNORED/FAILED summary, UNTRUSTED failure details dump |

## Verification

- `tsc --noEmit` ✅
- `vitest run` — 149/149 tests pass ✅