### PR TITLE
fix: standalone pino loggers now respect LOG_LEVEL env var

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,9 @@ import { connectRedis, disconnectRedis } from './cache/redis-client.js';
 import { startPollingLoop } from './polling/polling-loop.js';
 import { createInjectDidRoute } from './routes/inject-did.js';
 import { registerSwagger } from './swagger.js';
-import pino from 'pino';
+import { createLogger } from './logger.js';
 
-const logger = pino({ name: 'main' });
+const logger = createLogger('main');
 
 async function main(): Promise<void> {
   const config = loadConfig();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,7 @@
+import pino from 'pino';
+
+const level = process.env.LOG_LEVEL ?? 'info';
+
+export function createLogger(name: string): pino.Logger {
+  return pino({ name, level });
+}

--- a/src/polling/indexer-ws.ts
+++ b/src/polling/indexer-ws.ts
@@ -1,6 +1,6 @@
-import pino from 'pino';
+import { createLogger } from '../logger.js';
 
-const logger = pino({ name: 'indexer-ws' });
+const logger = createLogger('indexer-ws');
 
 const MAX_BACKOFF_MS = 30_000;
 const INITIAL_BACKOFF_MS = 1_000;
@@ -13,7 +13,7 @@ export interface BlockProcessedEvent {
 
 /**
  * Derives the WebSocket URL from the Indexer HTTP API URL.
- * http(s)://host:port/... → ws(s)://host:port/verana/indexer/v1/events
+ * http(s)://host:port/... \u2192 ws(s)://host:port/verana/indexer/v1/events
  */
 export function deriveWsUrl(indexerApi: string): string {
   const url = new URL(indexerApi);

--- a/src/polling/pass1.ts
+++ b/src/polling/pass1.ts
@@ -5,9 +5,9 @@ import { resolveDID } from '../ssi/did-resolver.js';
 import { dereferenceAllVPs } from '../ssi/vp-dereferencer.js';
 import { addReattemptable } from './reattemptable.js';
 import { markUntrusted } from '../trust/trust-store.js';
-import pino from 'pino';
+import { createLogger } from '../logger.js';
 
-const logger = pino({ name: 'pass1' });
+const logger = createLogger('pass1');
 
 export function extractAffectedDids(activity: ActivityItem[]): Set<string> {
   const dids = new Set<string>();

--- a/src/polling/pass2.ts
+++ b/src/polling/pass2.ts
@@ -2,9 +2,9 @@ import type { IndexerClient } from '../indexer/client.js';
 import { resolveTrust, createEvaluationContext } from '../trust/resolve-trust.js';
 import { upsertTrustResult } from '../trust/trust-store.js';
 import { addReattemptable } from './reattemptable.js';
-import pino from 'pino';
+import { createLogger } from '../logger.js';
 
-const logger = pino({ name: 'pass2' });
+const logger = createLogger('pass2');
 
 export async function runPass2(
   affectedDids: Set<string>,

--- a/src/polling/polling-loop.ts
+++ b/src/polling/polling-loop.ts
@@ -8,9 +8,9 @@ import { getRetryEligible, removeReattemptable, cleanupExpiredRetries } from './
 import { markUntrusted } from '../trust/trust-store.js';
 import { getPool } from '../db/index.js';
 import { IndexerWebSocket } from './indexer-ws.js';
-import pino from 'pino';
+import { createLogger } from '../logger.js';
 
-const logger = pino({ name: 'polling-loop' });
+const logger = createLogger('polling-loop');
 
 export interface PollingLoopOptions {
   indexer: IndexerClient;

--- a/src/routes/inject-did.ts
+++ b/src/routes/inject-did.ts
@@ -3,9 +3,9 @@ import type { IndexerClient } from '../indexer/client.js';
 import type { EnvConfig } from '../config/index.js';
 import { runPass1 } from '../polling/pass1.js';
 import { runPass2 } from '../polling/pass2.js';
-import pino from 'pino';
+import { createLogger } from '../logger.js';
 
-const logger = pino({ name: 'inject-did' });
+const logger = createLogger('inject-did');
 
 interface InjectDidBody {
   did: string;

--- a/src/ssi/did-resolver.ts
+++ b/src/ssi/did-resolver.ts
@@ -4,9 +4,9 @@ import { getResolver as getWebDidResolver } from 'web-did-resolver';
 import { resolveDID as resolveWebVh } from 'didwebvh-ts';
 import { getCachedFile, setCachedFile } from '../cache/file-cache.js';
 import type { ResolvedDIDDocument, DereferenceError } from './types.js';
-import pino from 'pino';
+import { createLogger } from '../logger.js';
 
-const logger = pino({ name: 'did-resolver' });
+const logger = createLogger('did-resolver');
 
 // did:web resolver via DIF web-did-resolver
 const webResolver = new Resolver(getWebDidResolver());

--- a/src/ssi/vp-dereferencer.ts
+++ b/src/ssi/vp-dereferencer.ts
@@ -1,9 +1,9 @@
 import { getCachedFile, setCachedFile } from '../cache/file-cache.js';
 import type { LinkedVPEndpoint, DereferencedVP, DereferenceError } from './types.js';
 import { extractCredentialsFromVP } from './vc-verifier.js';
-import pino from 'pino';
+import { createLogger } from '../logger.js';
 
-const logger = pino({ name: 'vp-dereferencer' });
+const logger = createLogger('vp-dereferencer');
 const LINKED_VP_TYPE = 'LinkedVerifiablePresentation';
 const FETCH_TIMEOUT_MS = 10_000;
 

--- a/src/trust/evaluate-credential.ts
+++ b/src/trust/evaluate-credential.ts
@@ -11,9 +11,9 @@ import type {
   EvaluationContext,
   FailedCredential,
 } from './types.js';
-import pino from 'pino';
+import { createLogger } from '../logger.js';
 
-const logger = pino({ name: 'evaluate-credential' });
+const logger = createLogger('evaluate-credential');
 
 const ECS_TYPE_PATTERNS: Array<{ pattern: RegExp; ecsType: EcsType }> = [
   { pattern: /ecs-service/i, ecsType: 'ECS-SERVICE' },

--- a/src/trust/resolve-trust.ts
+++ b/src/trust/resolve-trust.ts
@@ -9,9 +9,9 @@ import type {
   FailedCredential,
   EvaluationContext,
 } from './types.js';
-import pino from 'pino';
+import { createLogger } from '../logger.js';
 
-const logger = pino({ name: 'resolve-trust' });
+const logger = createLogger('resolve-trust');
 
 export async function resolveTrust(
   did: string,

--- a/src/trust/vs-requirements.ts
+++ b/src/trust/vs-requirements.ts
@@ -1,8 +1,8 @@
 import type { IndexerClient } from '../indexer/client.js';
 import type { CredentialEvaluation, EvaluationContext, TrustResult, TrustStatus } from './types.js';
-import pino from 'pino';
+import { createLogger } from '../logger.js';
 
-const logger = pino({ name: 'vs-requirements' });
+const logger = createLogger('vs-requirements');
 
 /**
  * Evaluate VS-REQ-2/3/4 requirements.


### PR DESCRIPTION
## Problem

All standalone `pino({ name: '...' })` loggers defaulted to `level: 'info'`, ignoring the `LOG_LEVEL` environment variable. The debug-level logs added in PR #101 were silently suppressed — only Fastify's own logger respected `LOG_LEVEL`.

## Fix

Introduces `src/logger.ts` with a `createLogger(name)` factory that reads `process.env.LOG_LEVEL` (defaulting to `'info'`). All 11 modules now use `createLogger()` instead of direct `pino()` instantiation.

## Files changed

| File | Change |
|------|--------|
| `src/logger.ts` | **New** — shared logger factory |
| `src/index.ts` | Use `createLogger('main')` |
| `src/ssi/did-resolver.ts` | Use `createLogger('did-resolver')` |
| `src/ssi/vp-dereferencer.ts` | Use `createLogger('vp-dereferencer')` |
| `src/polling/pass1.ts` | Use `createLogger('pass1')` |
| `src/polling/pass2.ts` | Use `createLogger('pass2')` |
| `src/polling/polling-loop.ts` | Use `createLogger('polling-loop')` |
| `src/polling/indexer-ws.ts` | Use `createLogger('indexer-ws')` |
| `src/trust/resolve-trust.ts` | Use `createLogger('resolve-trust')` |
| `src/trust/evaluate-credential.ts` | Use `createLogger('evaluate-credential')` |
| `src/trust/vs-requirements.ts` | Use `createLogger('vs-requirements')` |
| `src/routes/inject-did.ts` | Use `createLogger('inject-did')` |

## Usage

Set `LOG_LEVEL=debug` in `.env` to see all debug-level logs from PR #101.

## Verification

- `tsc --noEmit` ✅
- `vitest run` — 149/149 tests pass ✅