### PR TITLE
fix: register did:webvh resolver in Credo agent for signature verification

### DIFF
--- a/src/ssi/agent.ts
+++ b/src/ssi/agent.ts
@@ -3,6 +3,7 @@ import { agentDependencies } from '@credo-ts/node';
 import { DrizzleStorageModule } from '@credo-ts/drizzle-storage';
 import { coreBundle } from '@credo-ts/drizzle-storage/core';
 import { drizzle } from 'drizzle-orm/node-postgres';
+import { WebVhDidResolver } from './webvh-credo-resolver.js';
 
 let _agent: Agent | null = null;
 
@@ -19,7 +20,7 @@ export async function initializeAgent(postgresUrl: string): Promise<Agent> {
         bundles: [coreBundle],
       }),
       dids: new DidsModule({
-        resolvers: [new WebDidResolver()],
+        resolvers: [new WebDidResolver(), new WebVhDidResolver()],
       }),
       w3cCredentials: new W3cCredentialsModule(),
     },

--- a/src/ssi/vc-verifier.ts
+++ b/src/ssi/vc-verifier.ts
@@ -89,8 +89,10 @@ export async function verifyW3cCredential(
     }
 
     if (!result.isValid) {
-      const errorMsg = result.error?.message ?? 'Credential verification failed';
-      return { verified: false, error: errorMsg };
+      // Surface detailed error: Credo wraps inner errors in result.error.cause
+      const cause = (result.error as Error & { cause?: Error })?.cause;
+      const details = cause?.message ?? result.error?.message ?? 'Credential verification failed';
+      return { verified: false, error: details };
     }
 
     return { verified: true };

--- a/src/ssi/webvh-credo-resolver.ts
+++ b/src/ssi/webvh-credo-resolver.ts
@@ -1,0 +1,73 @@
+import { createPublicKey, verify } from 'node:crypto';
+import { JsonTransformer, DidDocument } from '@credo-ts/core';
+import type { AgentContext } from '@credo-ts/core';
+import { resolveDID as resolveWebVh } from 'didwebvh-ts';
+
+// Ed25519 verifier for didwebvh-ts (uses Node.js built-in crypto)
+const ED25519_SPKI_PREFIX = Buffer.from([0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00]);
+const ed25519Verifier = {
+  async verify(signature: Uint8Array, message: Uint8Array, publicKey: Uint8Array): Promise<boolean> {
+    const key = createPublicKey({
+      key: Buffer.concat([ED25519_SPKI_PREFIX, Buffer.from(publicKey)]),
+      format: 'der',
+      type: 'spki',
+    });
+    return verify(null, message, key, signature);
+  },
+};
+
+/**
+ * Custom Credo DID resolver for did:webvh.
+ *
+ * Wraps the DIF didwebvh-ts reference implementation so that
+ * Credo's W3cCredentialsModule can resolve did:webvh issuer DIDs
+ * during credential signature verification.
+ */
+export class WebVhDidResolver {
+  readonly supportedMethods = ['webvh'];
+  readonly allowsCaching = true;
+  readonly allowsLocalDidRecord = false;
+
+  async resolve(
+    _agentContext: AgentContext,
+    did: string,
+  ): Promise<{
+    didResolutionMetadata: Record<string, unknown>;
+    didDocument: DidDocument | null;
+    didDocumentMetadata: Record<string, unknown>;
+  }> {
+    try {
+      const resolution = await resolveWebVh(did, { verifier: ed25519Verifier });
+
+      if (resolution.meta?.error || !resolution.doc) {
+        return {
+          didResolutionMetadata: {
+            error: resolution.meta?.error ?? 'notFound',
+            message: resolution.meta?.problemDetails?.detail,
+          },
+          didDocument: null,
+          didDocumentMetadata: {},
+        };
+      }
+
+      const didDocument = JsonTransformer.fromJSON(resolution.doc, DidDocument);
+
+      return {
+        didResolutionMetadata: {},
+        didDocument,
+        didDocumentMetadata: {
+          updated: resolution.meta?.updated,
+        },
+      };
+    } catch (err) {
+      return {
+        didResolutionMetadata: {
+          error: 'notFound',
+          message: err instanceof Error ? err.message : String(err),
+        },
+        didDocument: null,
+        didDocumentMetadata: {},
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Problem

All W3C JSON-LD credential signature verifications fail with `"Verification error(s)."` for credentials issued by `did:webvh` DIDs.

**Root cause:** The Credo agent only had `WebDidResolver` (`did:web`) registered. When `W3cCredentialsModule.verifyCredential()` tries to resolve the issuer's DID to obtain the public key for signature verification, it fails because there's no resolver for `did:webvh`.

```json
{"name":"evaluate-credential","vcId":"...schemas-service-jsc.json","error":"Verification error(s).","msg":"Credential signature verification FAILED"}
```

## Fix

### 1. Custom Credo DID resolver for `did:webvh` (`src/ssi/webvh-credo-resolver.ts`)

New `WebVhDidResolver` class implementing Credo's `DidResolver` interface. It wraps the DIF `didwebvh-ts` reference implementation (already a project dependency) with a Node.js built-in Ed25519 verifier — the same approach used in `src/ssi/did-resolver.ts` for the resolver's own DID resolution.

### 2. Agent registration (`src/ssi/agent.ts`)

```diff
- resolvers: [new WebDidResolver()],
+ resolvers: [new WebDidResolver(), new WebVhDidResolver()],
```

### 3. Better error details (`src/ssi/vc-verifier.ts`)

Unwraps Credo's nested `result.error.cause` to surface the actual failure reason instead of the generic `"Verification error(s)."` message.

## Files changed

| File | Change |
|------|--------|
| `src/ssi/webvh-credo-resolver.ts` | **New** — custom Credo DID resolver for `did:webvh` |
| `src/ssi/agent.ts` | Register `WebVhDidResolver` alongside `WebDidResolver` |
| `src/ssi/vc-verifier.ts` | Unwrap nested error details from Credo verification result |

## Verification

- `tsc --noEmit` ✅
- `vitest run` — 149/149 tests pass ✅