### PR TITLE
fix: resolve VPR URIs for schema lookup and improve credential evaluation logging

### DIFF
--- a/src/indexer/client.ts
+++ b/src/indexer/client.ts
@@ -74,6 +74,13 @@ export class IndexerClient {
     return this.get<CredentialSchemaResponse>(`/verana/cs/v1/get/${id}`, {}, atBlock);
   }
 
+  async getCredentialSchemaByJsonSchemaId(
+    jsId: string,
+    atBlock?: number,
+  ): Promise<CredentialSchemaResponse> {
+    return this.get<CredentialSchemaResponse>(`/verana/cs/v1/js/${jsId}`, {}, atBlock);
+  }
+
   async listCredentialSchemas(
     params: ListCredentialSchemasParams = {},
     atBlock?: number,

--- a/src/ssi/vc-verifier.ts
+++ b/src/ssi/vc-verifier.ts
@@ -68,6 +68,16 @@ export function extractIssuerDid(vc: Record<string, unknown>): string {
 }
 
 export function extractCredentialSchemaId(vc: Record<string, unknown>): string | undefined {
+  // 1. For JsonSchemaCredentials (VTJSCs): the VPR URI is in credentialSubject.id
+  const subject = vc.credentialSubject;
+  if (typeof subject === 'object' && subject !== null) {
+    const subjectId = (subject as Record<string, unknown>).id;
+    if (typeof subjectId === 'string' && subjectId.startsWith('vpr:')) {
+      return subjectId;
+    }
+  }
+
+  // 2. For regular VCs: credentialSchema.id points to the VTJSC URL
   const credentialSchema = vc.credentialSchema;
   if (!credentialSchema) {
     // AnonCreds: check relatedJsonSchemaCredentialId


### PR DESCRIPTION
## Summary

Fix schema resolution for credentials that reference VPR URIs (e.g. `vpr:verana:vna-testnet-1/cs/v1/js/47`), verify the digestSRI of resolved JSON schemas, and improve logging throughout credential evaluation.

## Problems Fixed

1. **Schema extraction was wrong for VTJSCs**: `extractCredentialSchemaId` only checked `credentialSchema.id`, which for JsonSchemaCredentials returns the W3C meta-schema URL — useless for on-chain lookup. The actual VPR URI is in `credentialSubject.id`.

2. **No VPR URI resolution**: `resolveVtjscToSchema` listed all schemas and did a client-side string match. No ability to resolve `vpr:verana:` URIs to indexer endpoints.

3. **No digestSRI verification**: JSON schema content from the VPR was not verified against the VTJSC's `credentialSubject.digestSRI`.

4. **Opaque failure logging**: The `ISSUER permission NOT found` log didn't indicate whether the schema wasn't found or the permission wasn't found.

## Changes

### `src/ssi/vc-verifier.ts`
- `extractCredentialSchemaId` now checks `credentialSubject.id` for VPR URIs first (handles VTJSCs), then falls back to `credentialSchema.id` (handles regular VCs)

### `src/ssi/digest.ts`
- New `verifySriDigest(content, expectedSri)` — JCS-canonicalizes content and verifies SRI digest (supports sha256/sha384/sha512)

### `src/indexer/client.ts`
- New `getCredentialSchemaByJsonSchemaId(jsId)` → `/verana/cs/v1/js/{id}` (metadata)
- New `fetchJsonSchemaContent(jsId)` → `/verana/cs/v1/js/{id}/content` (raw JSON schema for digest verification)

### `src/trust/evaluate-credential.ts`
- New `parseVprJsonSchemaId()` — parses `vpr:verana:vna-testnet-1/cs/v1/js/47` → `47`
- `resolveVtjscToSchema`: VPR URI → indexer `/verana/cs/v1/js/{id}`, fallback to `listCredentialSchemas` filter
- **Step 2b**: After schema resolution, fetches JSON schema content and verifies `credentialSubject.digestSRI`. Fails with `DIGEST_SRI_MISMATCH` on mismatch.
- Logging: `info`/`warn` levels for key steps, structured context with all relevant IDs, failure reason distinguishes "schema not found" vs "permission not found"

## Verification

- `tsc --noEmit` ✅
- `vitest run` — 16 test files, 149 tests, all passing ✅