### PR TITLE
fix: dereference VTJSC URLs for regular VCs and verify digestSRI

### DIFF
--- a/src/indexer/client.ts
+++ b/src/indexer/client.ts
@@ -81,6 +81,13 @@ export class IndexerClient {
     return this.get<CredentialSchemaResponse>(`/verana/cs/v1/js/${jsId}`, {}, atBlock);
   }
 
+  async fetchJsonSchemaContent(
+    jsId: string,
+    atBlock?: number,
+  ): Promise<Record<string, unknown>> {
+    return this.get<Record<string, unknown>>(`/verana/cs/v1/js/${jsId}/content`, {}, atBlock);
+  }
+
   async listCredentialSchemas(
     params: ListCredentialSchemasParams = {},
     atBlock?: number,


### PR DESCRIPTION
## Summary

Fix schema resolution for regular VCs whose `credentialSchema.id` is a VTJSC URL, and add digestSRI verification for JSON schema content.

## Problem

For regular VCs (e.g. organization credentials), `credentialSchema.id` is a VTJSC URL like `https://dm.gov-id-tr.demos.2060.io/vt/schemas-organization-jsc.json`. The VPR URI is **inside** the VTJSC's `credentialSubject.id`, not directly accessible from the VC. PR #107 only handled VPR URIs and the `listCredentialSchemas` fallback — neither works for this case.

Additionally, JSON schema content from the VPR was not verified against the VTJSC's `credentialSubject.digestSRI`.

## Changes

### `src/trust/evaluate-credential.ts`
- **VTJSC URL dereference** (step 2 in `resolveVtjscToSchema`): When `vtjscId` is an HTTPS URL, fetch the VTJSC, extract the VPR URI from `credentialSubject.id`, then resolve via indexer `/verana/cs/v1/js/{id}`
- **digestSRI verification** (step 2b in `evaluateCredential`): After schema resolution, if `credentialSubject.digestSRI` exists, fetch JSON schema content and verify SRI digest. Fails with `DIGEST_SRI_MISMATCH` on mismatch.

### `src/ssi/digest.ts`
- New `verifySriDigest(content, expectedSri)` — JCS-canonicalizes, hashes with algorithm from SRI prefix (sha256/sha384/sha512), compares

### `src/indexer/client.ts`
- New `fetchJsonSchemaContent(jsId)` → `/verana/cs/v1/js/{id}/content`

## Resolution flow (3 strategies)

1. **VPR URI** (`vpr:verana:...`) → resolve directly via indexer
2. **HTTPS URL** → fetch VTJSC → extract VPR URI from `credentialSubject.id` → resolve via indexer
3. **Fallback** → `listCredentialSchemas({ json_schema })` filter

## Verification

- `tsc --noEmit` ✅
- `vitest run` — 16 test files, 149 tests, all passing ✅