### PR TITLE
fix: detect VTJSCs by type for correct schema reference extraction

### DIFF
--- a/src/ssi/vc-verifier.ts
+++ b/src/ssi/vc-verifier.ts
@@ -68,16 +68,6 @@ export function extractIssuerDid(vc: Record<string, unknown>): string {
 }
 
 export function extractCredentialSchemaId(vc: Record<string, unknown>): string | undefined {
-  // 1. For JsonSchemaCredentials (VTJSCs): the VPR URI is in credentialSubject.id
-  const subject = vc.credentialSubject;
-  if (typeof subject === 'object' && subject !== null) {
-    const subjectId = (subject as Record<string, unknown>).id;
-    if (typeof subjectId === 'string' && subjectId.startsWith('vpr:')) {
-      return subjectId;
-    }
-  }
-
-  // 2. For regular VCs: credentialSchema.id points to the VTJSC URL
   const credentialSchema = vc.credentialSchema;
   if (!credentialSchema) {
     // AnonCreds: check relatedJsonSchemaCredentialId


### PR DESCRIPTION
## Summary

Fixes schema resolution by addressing two root causes:

### 1. VTJSC detection by type in evaluator
- Detect VTJSCs by checking `vc.type` for `"JsonSchemaCredential"`
- Extract VPR URI from `credentialSubject.id` for VTJSCs
- Use `credentialSchema.id` (VTJSC URL) for regular VCs
- Revert `extractCredentialSchemaId` to its original simple form

### 2. Indexer API response shape mismatch (critical bug)
The indexer API returns different response shapes than what the code expected:
- `/verana/cs/v1/list` returns `{schemas: [...]}` — code expected `{credential_schemas: [...]}`
- `/verana/cs/v1/js/{id}` returns `{schema: "..."}` (JSON content string) — code expected `{credential_schema: {...}}`
- `json_schema` field in CredentialSchema is the **full JSON schema content as a string**, not a URL

This mismatch caused ALL schema lookups to silently return `undefined`, leading to every credential failing with "schema not found on-chain".

### Changes
- Fix `CredentialSchemaListResponse` → `schemas` key
- Fix `CredentialSchemaResponse` → `schema` key  
- Add `JsonSchemaContentResponse` type for `/js/{id}` endpoint
- Remove `getCredentialSchemaByJsonSchemaId` (returned content, not metadata)
- Fix `fetchJsonSchemaContent` to parse string response from `/js/{id}`
- Rewrite `resolveVtjscToSchema` to search by `$id` in parsed `json_schema` content
- Update all route handlers and tests for new response keys

### Files changed
- `src/indexer/types.ts` — response type fixes
- `src/indexer/client.ts` — remove broken method, fix fetchJsonSchemaContent
- `src/trust/evaluate-credential.ts` — VTJSC detection + rewritten resolveVtjscToSchema
- `src/routes/q2-issuer-auth.ts` — schemas key fix
- `src/routes/q3-verifier-auth.ts` — schemas key fix
- `src/routes/q4-ecosystem-participant.ts` — schemas key fix
- `test/q2-issuer-auth.test.ts` — mock response key fix
- `test/q3-verifier-auth.test.ts` — mock response key fix
- `test/q4-ecosystem-participant.test.ts` — mock response key fix

### Testing
- TypeScript compiles clean (`tsc --noEmit`)
- All 149 tests pass across 16 test files