### PR TITLE
fix: create refresh endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The **Verana Trust Resolver** is a core infrastructure component of the [Verana]
 | `GET /v1/trust/issuer-authorization` | Q2 — Check if a DID is an authorized issuer for a credential schema |
 | `GET /v1/trust/verifier-authorization` | Q3 — Check if a DID is an authorized verifier for a credential schema |
 | `GET /v1/trust/ecosystem-participant` | Q4 — Check if a DID holds any active permissions in an ecosystem |
+| `GET /v1/trust/refresh` | Q5 — Refresh and check trust resolution for a unique DID |
 | `GET /v1/health` | Health check |
 
 ## Container Environment Variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@fastify/cors": "^11.0.0",
         "@fastify/swagger": "^9.7.0",
         "@fastify/swagger-ui": "^5.2.5",
-        "@verana-labs/verre": "^0.2.4",
+        "@verana-labs/verre": "^0.2.5",
         "dotenv": "^17.3.1",
         "fastify": "^5.2.1",
         "ioredis": "^5.4.2",
@@ -1309,9 +1309,9 @@
       }
     },
     "node_modules/@verana-labs/verre": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@verana-labs/verre/-/verre-0.2.4.tgz",
-      "integrity": "sha512-b+zxK1AsJ0FqEgtLsOxQThZAuRfOeCGprHUH0SngfjRvi9LHPTHeGC3ZdWlHnzy9Dh8xGGqdzNxuJx15IodwTg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@verana-labs/verre/-/verre-0.2.5.tgz",
+      "integrity": "sha512-c7R+kFNQJMOU7So6KHUT+0pPBOIMTd9R3MHO2GcFc8/PD32mb52GJoBz4xH0V3cbpkyLBVoCCtqHhnqIUjAliw==",
       "dependencies": {
         "@digitalcredentials/jsonld": "^9.0.0",
         "@noble/curves": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@fastify/cors": "^11.0.0",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.5",
-    "@verana-labs/verre": "^0.2.4",
+    "@verana-labs/verre": "^0.2.5",
     "dotenv": "^17.3.1",
     "fastify": "^5.2.1",
     "ioredis": "^5.4.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { runMigrations } from './db/migrate.js';
 import { connectRedis, disconnectRedis } from './cache/redis-client.js';
 import { startPollingLoop, parseVprRegistries } from './polling/polling-loop.js';
 import { createInjectDidRoute } from './routes/inject-did.js';
+import { createQ5oute } from './routes/refresh.js';
 import { registerSwagger } from './swagger.js';
 import { createLogger } from './logger.js';
 
@@ -69,6 +70,7 @@ async function main(): Promise<void> {
   await createQ2Route(parseVprRegistries(config.VPR_REGISTRIES))(server);
   await createQ3Route(parseVprRegistries(config.VPR_REGISTRIES))(server);
   await createQ4Route(indexer)(server);
+  await createQ5oute(indexer, config)(server);
 
   // Dev-mode: inject DID endpoint
   if (config.INJECT_DID_ENDPOINT_ENABLED) {

--- a/src/routes/refresh.ts
+++ b/src/routes/refresh.ts
@@ -1,0 +1,108 @@
+import type { FastifyInstance } from 'fastify';
+import type { IndexerClient } from '../indexer/client.js';
+import type { EnvConfig } from '../config/index.js';
+import { runVerrePass, parseVprRegistries } from '../polling/index.js';
+import { invalidateTrustTtl } from '../trust/trust-store.js';
+import { removeReattemptable } from '../polling/reattemptable.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('refresh-did');
+
+interface RefreshDidBody {
+  did: string;
+}
+
+interface RefreshDidResponse {
+  did: string;
+  result: 'ok' | 'failed';
+}
+
+export function createQ5oute(
+  indexer: IndexerClient,
+  config: EnvConfig,
+): (server: FastifyInstance) => Promise<void> {
+  return async (server: FastifyInstance) => {
+    server.post<{ Body: RefreshDidBody }>('/v1/trust/refresh', {
+      schema: {
+        tags: ['Trust'],
+        summary: 'Force refresh trust evaluation for a DID',
+        description: 'Forces DID resolution + VP dereferencing + trust evaluation, bypassing cache/TTL behavior.',
+        body: {
+          type: 'object',
+          properties: {
+            did: { type: 'string', description: 'DID to refresh (e.g. did:web:example.com)' },
+          },
+          required: ['did'],
+        },
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              did: { type: 'string' },
+              result: { type: 'string', enum: ['ok', 'failed'] },
+            },
+          },
+          400: {
+            type: 'object',
+            properties: { error: { type: 'string' }, message: { type: 'string' } },
+          },
+        },
+      },
+    }, async (request, reply) => {
+      const { did } = request.body ?? {};
+
+      if (!did || typeof did !== 'string' || !did.startsWith('did:')) {
+        return reply.status(400).send({
+          error: 'Bad Request',
+          message: 'Request body must contain a valid "did" string starting with "did:"',
+        });
+      }
+
+      logger.info({ did }, 'Forcing trust refresh for DID');
+
+      try {
+        // Parse VPR registries
+        const verifiablePublicRegistries = parseVprRegistries(config.VPR_REGISTRIES);
+        const skipDigestSRICheck = config.DISABLE_DIGEST_SRI_VERIFICATION;
+
+        // Get current block height
+        const heightResp = await indexer.getBlockHeight();
+        const currentBlock = heightResp.height;
+
+        // Invalidate existing TTL so the polling loop re-evaluates if this call fails
+        await invalidateTrustTtl(did);
+
+        const affectedDids = new Set([did]);
+        const passResult = await runVerrePass(
+          affectedDids,
+          indexer,
+          currentBlock,
+          config.TRUST_TTL,
+          verifiablePublicRegistries,
+          skipDigestSRICheck,
+        );
+
+        // If resolution succeeded, remove from reattemptable in case it was queued
+        if (passResult.succeeded.includes(did)) {
+          await removeReattemptable(did);
+        }
+
+        const response: RefreshDidResponse = {
+          did,
+          result: passResult.succeeded.includes(did) ? 'ok' : 'failed',
+        };
+
+        logger.info({ did, result: response.result }, 'Trust refresh complete');
+        return reply.send(response);
+
+      } catch (error) {
+        logger.error({ did, error }, 'Error refreshing DID');
+
+        return reply.status(500).send({
+          error: 'Internal Server Error',
+          message: 'Failed to refresh DID trust evaluation',
+        });
+      }
+    });
+  };
+}

--- a/src/trust/trust-store.ts
+++ b/src/trust/trust-store.ts
@@ -43,6 +43,14 @@ export async function getFullTrustResult(did: string): Promise<TrustResult | nul
   return row.rows[0].full_result_json as TrustResult;
 }
 
+export async function invalidateTrustTtl(did: string): Promise<void> {
+  const pool = getPool();
+  await pool.query(
+    `UPDATE trust_results SET expires_at = NOW() WHERE did = $1`,
+    [did],
+  );
+}
+
 export async function markUntrusted(did: string, block: number, ttlSeconds: number): Promise<void> {
   const pool = getPool();
   const now = new Date();


### PR DESCRIPTION
This new endpoint is based on `v1/inject/did`. The main difference is that it includes the `invalidateTrustTtl` function, which updates the TTL validation to allow refreshing the DID. 
@genaris, I would prefer to keep only one endpoint (possibly the refresh one, since it better aligns with the process) and remove the `v1/inject/did` endpoint. 
**Note:** This change requires verre v0.2.5 (https://github.com/verana-labs/verre/pull/95) which fixes a cache-related bug where no timeout was implemented.