### PR TITLE
fix: expose service/org logo and persona avatar in resolved claims

### DIFF
--- a/src/polling/verre-pass.ts
+++ b/src/polling/verre-pass.ts
@@ -64,7 +64,7 @@ function mapEcsType(schemaType: ICredential['schemaType']): EcsType {
   }
 }
 
-function extractClaimsFromCredential(cred: ICredential): Record<string, unknown> {
+export function extractClaimsFromCredential(cred: ICredential): Record<string, unknown> {
   const claims: Record<string, unknown> = { id: cred.id, issuer: cred.issuer };
 
   switch (cred.schemaType) {
@@ -73,6 +73,7 @@ function extractClaimsFromCredential(cred: ICredential): Record<string, unknown>
       claims.name = svc.name;
       claims.type = svc.type;
       claims.description = svc.description;
+      claims.logo = svc.logo;
       claims.minimumAgeRequired = svc.minimumAgeRequired;
       claims.termsAndConditions = svc.termsAndConditions;
       claims.termsAndConditionsDigestSri = svc.termsAndConditionsDigestSri;
@@ -83,6 +84,7 @@ function extractClaimsFromCredential(cred: ICredential): Record<string, unknown>
     case ECS.ORG: {
       const org = cred as IOrg;
       claims.name = org.name;
+      claims.logo = org.logo;
       claims.registryId = org.registryId;
       claims.registryUri = org.registryUri;
       claims.address = org.address;
@@ -95,6 +97,7 @@ function extractClaimsFromCredential(cred: ICredential): Record<string, unknown>
     case ECS.PERSONA: {
       const persona = cred as IPersona;
       claims.name = persona.name;
+      claims.avatar = persona.avatar;
       claims.controllerCountryCode = persona.controllerCountryCode;
       claims.controllerJurisdiction = persona.controllerJurisdiction;
       claims.description = persona.description;

--- a/test/claims-mapping.test.ts
+++ b/test/claims-mapping.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { ECS } from '@verana-labs/verre';
+import type { IOrg, IPersona, IService } from '@verana-labs/verre';
+import { extractClaimsFromCredential } from '../src/polling/verre-pass.js';
+
+const service: IService = {
+  schemaType: ECS.SERVICE,
+  id: 'did:web:service.example',
+  issuer: 'did:web:issuer.example',
+  name: 'Acme Portal',
+  type: 'WebService',
+  description: 'Acme customer portal',
+  logo: 'https://service.example/logo.png',
+  minimumAgeRequired: 0,
+  termsAndConditions: 'https://service.example/terms',
+  privacyPolicy: 'https://service.example/privacy',
+};
+
+const org: IOrg = {
+  schemaType: ECS.ORG,
+  id: 'did:web:service.example',
+  issuer: 'did:web:ecs.example',
+  name: 'Acme Corp',
+  logo: 'https://service.example/org-logo.png',
+  registryId: 'BE0123456789',
+  address: 'Rue de la Loi 1, 1000 Brussels',
+  countryCode: 'BE',
+};
+
+const persona: IPersona = {
+  schemaType: ECS.PERSONA,
+  id: 'did:web:persona.example',
+  issuer: 'did:web:ecs.example',
+  name: '@fabrice',
+  avatar: 'https://persona.example/avatar.png',
+  controllerCountryCode: 'CO',
+};
+
+describe('extractClaimsFromCredential', () => {
+  it('keeps the service logo alongside the other ECS-SERVICE claims', () => {
+    const claims = extractClaimsFromCredential(service);
+    expect(claims.name).toBe('Acme Portal');
+    expect(claims.logo).toBe('https://service.example/logo.png');
+    expect(claims.termsAndConditions).toBe('https://service.example/terms');
+  });
+
+  it('keeps the organization logo alongside the other ECS-ORG claims', () => {
+    const claims = extractClaimsFromCredential(org);
+    expect(claims.name).toBe('Acme Corp');
+    expect(claims.logo).toBe('https://service.example/org-logo.png');
+    expect(claims.countryCode).toBe('BE');
+  });
+
+  it('keeps the persona avatar alongside the other ECS-PERSONA claims', () => {
+    const claims = extractClaimsFromCredential(persona);
+    expect(claims.name).toBe('@fabrice');
+    expect(claims.avatar).toBe('https://persona.example/avatar.png');
+    expect(claims.controllerCountryCode).toBe('CO');
+  });
+});


### PR DESCRIPTION
## Problem

`/v1/trust/resolve` responses never include the service or organization logo: verre delivers `IService.logo`, `IOrg.logo` and `IPersona.avatar`, but `extractClaimsFromCredential()` in `src/polling/verre-pass.ts` copies a hand-picked whitelist of claims and silently drops those fields. Confirmed live against `resolver.testnet.verana.network` — ECS-SERVICE and ECS-ORG claims come back without any logo field. As a result, consumers such as verana-frontend cards cannot render the real service/org icon (companion frontend PR follows).

## Change

- `claims.logo` is now copied for `ECS-SERVICE` and `ECS-ORG` credentials, and `claims.avatar` for `ECS-PERSONA`.
- Exported `extractClaimsFromCredential` and added `test/claims-mapping.test.ts` as a regression guard against silently dropped claim fields.

## Testing

- `npm run build` — clean.
- `npm test` — 14 files, 108 tests passing (3 new).